### PR TITLE
feat: update public and recent tables

### DIFF
--- a/src/components/Paginations/Pagination.tsx
+++ b/src/components/Paginations/Pagination.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+
+import { useSearchParams, usePathname } from 'next/navigation';
+
+export default function Pagination({
+    totalPages,
+} : {
+    totalPages: number;
+}) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const currentPage = Number(searchParams.get('page')) || 1;  
+  const pageIndexes = Array.from({length: totalPages}, (_, i) => i + 1);
+
+  const createPageURL = (targetPage:number):string => {
+    if (targetPage >= 1 && targetPage <= totalPages) {
+      const params = new URLSearchParams(searchParams);
+      params.set('page', targetPage.toString());
+      return `${pathname}?${params.toString()}`;  
+    }
+    return "#";
+  };
+
+  return (
+    <div className="p-4 sm:p-6 xl:p-7.5">
+        <nav>
+          <ul className="flex flex-wrap items-center">
+            <li>
+              <Link
+                className={`flex h-9 w-9 items-center justify-center rounded-l-md border border-stroke ${currentPage == 1 ? "pointer-events-none" : "hover:border-primary hover:bg-gray hover:text-primary"}`}
+                href={createPageURL(currentPage-1)}
+              >
+                <svg
+                  className="fill-current"
+                  width="8"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M7.17578 15.1156C7.00703 15.1156 6.83828 15.0593 6.72578 14.9187L0.369531 8.44995C0.116406 8.19683 0.116406 7.80308 0.369531 7.54995L6.72578 1.0812C6.97891 0.828076 7.37266 0.828076 7.62578 1.0812C7.87891 1.33433 7.87891 1.72808 7.62578 1.9812L1.71953 7.99995L7.65391 14.0187C7.90703 14.2718 7.90703 14.6656 7.65391 14.9187C7.48516 15.0312 7.34453 15.1156 7.17578 15.1156Z"
+                    fill=""
+                  />
+                </svg>
+              </Link>
+            </li>
+            { pageIndexes.map((i) => {
+                return (<li key={i}>
+                <Link
+                    className={`flex items-center justify-center border border-stroke border-l-transparent px-4 py-[5px] font-medium 
+                        ${ i ==  currentPage? "font-extrabold bg-gray" : "hover:border-primary hover:bg-gray hover:text-primary" }`}
+                    href={createPageURL(i)}
+                >
+                    {i}
+                </Link>
+                </li>);
+            })}
+            <li>
+              <Link
+                className={`flex h-9 w-9 items-center justify-center rounded-r-md border border-stroke border-l-transparent  ${currentPage == totalPages ? "pointer-events-none" : "hover:border-primary hover:bg-gray hover:text-primary"}`}
+                href={createPageURL(currentPage+1)}
+              >
+                <svg
+                  className="fill-current"
+                  width="8"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M0.819531 15.1156C0.650781 15.1156 0.510156 15.0593 0.369531 14.9468C0.116406 14.6937 0.116406 14.3 0.369531 14.0468L6.27578 7.99995L0.369531 1.9812C0.116406 1.72808 0.116406 1.33433 0.369531 1.0812C0.622656 0.828076 1.01641 0.828076 1.26953 1.0812L7.62578 7.54995C7.87891 7.80308 7.87891 8.19683 7.62578 8.44995L1.26953 14.9187C1.15703 15.0312 0.988281 15.1156 0.819531 15.1156Z"
+                    fill=""
+                  />
+                </svg>
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+  );
+};

--- a/src/components/Tables/Public.tsx
+++ b/src/components/Tables/Public.tsx
@@ -3,6 +3,7 @@ import { currentUser, clerkClient } from '@clerk/nextjs';
 import Image from 'next/image'
 
 import SearchBar from "@/components/Tables/Search";
+import Link from 'next/link';
 
 const xataClient = getXataClient();
 
@@ -33,9 +34,16 @@ export default async function PublicTable({
 
   const thisUser = await currentUser();
 
+  let searchedStudies = studies.toArray();
+  if (!!query) {
+    query = query.toLowerCase();
+    searchedStudies = studies.filter((study) => 
+      (study.name.toLowerCase().includes(query) || study.passage.toLowerCase().includes(query)));
+  } 
+
   return (
     <>
-    <SearchBar placeholder="Search study..." />
+    <SearchBar placeholder="Search study by name or passage..." />
     <div className="rounded-sm border border-stroke bg-white px-5 pt-6 pb-2.5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 xl:pb-1">
       <div className="max-w-full overflow-x-auto">
         <table className="w-full table-auto">
@@ -56,13 +64,15 @@ export default async function PublicTable({
             </tr>
           </thead>
           <tbody>
-            {studies.map((studyItem) => (
+            {searchedStudies.map((studyItem) => (
               <tr key={studyItem.id}>
                 <td className="border-b border-[#eee] py-5 px-4 pl-9 dark:border-strokedark xl:pl-11">
-                  <h5 className="font-medium text-black dark:text-white">
-                    {studyItem.name}
-                  </h5>
-                  <p className="text-sm">Psalm {studyItem.passage}</p>
+                  <Link href={"/study/" + studyItem.id.replace("rec_", "") + "/view"}>
+                    <h5 className="font-medium text-black dark:text-white">
+                      {studyItem.name}
+                    </h5>
+                  </Link>
+                  {/* <p className="text-sm">Psalm {studyItem.passage}</p> */}
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 pl-9 dark:border-strokedark xl:pl-11">
                   <p className="text-black dark:text-white">
@@ -74,7 +84,7 @@ export default async function PublicTable({
                     {studyItem.xata.updatedAt.toLocaleString()}
                   </p>
                 </td>
-                <td className="border-b border-[#eee] py-7 px-4 dark:border-strokedark flex items-center">
+                <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark flex items-center">
                   <div className="mr-3 h-8 w-full max-w-8 overflow-hidden rounded-full">
                     <Image src={mp.get(studyItem.owner)?.imageUrl} width="40" height="40" alt="Avatar" />
                   </div>

--- a/src/components/Tables/Public.tsx
+++ b/src/components/Tables/Public.tsx
@@ -16,7 +16,7 @@ export default async function PublicTable({
   currentPage: number;
 }) {
   // may make PAGINATION_SIZE editable by user later
-  const PAGINATION_SIZE = 5;
+  const PAGINATION_SIZE = 10;
   
   // fetch all studies from xata
   const search = await xataClient.db.study.search("", {

--- a/src/components/Tables/Recent.tsx
+++ b/src/components/Tables/Recent.tsx
@@ -7,6 +7,7 @@ import PublicSwitcher from '@/components/Tables/Recent/PublicSwitcher';
 import StarToggler from '@/components/Tables/Recent/StarToggler';
 import DeleteStudyModal from '@/components/Modals/DeleteStudy';
 import EditStudyModal from '@/components/Modals/EditStudy';
+import Pagination from "@/components/Paginations/Pagination";
 
 export default async function RecentTable({
   query,
@@ -15,10 +16,31 @@ export default async function RecentTable({
   query: string;
   currentPage: number;
 }) {
+  // may make PAGINATION_SIZE editable by user later
+  const PAGINATION_SIZE = 10;
+
   const user = await currentUser();
 
   const xataClient = getXataClient();
-  const studies = await xataClient.db.study.filter({ owner: user?.id }).getAll();
+  const search = await xataClient.db.study.search("", {
+    filter: {
+      $all:[
+        { owner: user?.id },
+        {
+          $any: [
+            { name: {$iContains: query }},
+            { passage: {$iContains: query }}
+          ]
+        },  
+      ]
+    },
+    page: {
+      size: PAGINATION_SIZE,
+      offset: (currentPage-1) * PAGINATION_SIZE
+    }
+  });
+  const studies = search.records;
+  const totalPages = Math.ceil(search.totalCount/PAGINATION_SIZE);
 
   return (
     <>
@@ -80,6 +102,13 @@ export default async function RecentTable({
           </tbody>
         </table>
       </div>
+      {
+        totalPages > 0 
+          ? <Pagination totalPages={ totalPages } /> 
+          : (<div className="text-center py-5">
+            <h2 className="text-xl"> No study found </h2>
+          </div>)
+      }
     </div>
     </>
   );

--- a/src/components/Tables/Recent.tsx
+++ b/src/components/Tables/Recent.tsx
@@ -44,7 +44,7 @@ export default async function RecentTable({
 
   return (
     <>
-    <SearchBar placeholder="Search study..." />
+    <SearchBar placeholder="Search study by name or passage..." />
     <div className="rounded-sm border border-stroke bg-white px-5 pt-6 pb-2.5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 xl:pb-1">
       <div className="max-w-full overflow-x-auto">
         <table className="w-full table-auto">


### PR DESCRIPTION
In this PR:
- add the link to the view study page in the study name
- fix search studies, users can search by study name or passage
  - use the search API by Xata to filter by search query (7.28 update)
- update styling, remove the bottom passage info in the study name cell, reduce padding-y of the owner cell
- add pagination for public table  (7.28 update)
- fix search and add pagination in recent table

Todo in this task (will add in this PR or another PR):
- Make public page and view study pages accessible to visitors (unsigned-in users)