### PR TITLE
fix: search box bug

### DIFF
--- a/src/components/Tables/Search.tsx
+++ b/src/components/Tables/Search.tsx
@@ -21,7 +21,7 @@ const SearchBar = ({ placeholder } : { placeholder: string }) => {
       params.delete('query');
     }
     replace(`${pathname}?${params.toString()}`);
-  }, 300);
+  }, 500);
   
   return (
     <div className="sm:block">


### PR DESCRIPTION
Bug description:
- When a user types at a certain speed, the last character input may not be captured by the search box due to the short debounce wait time

In this PR:
- Increase the debounce wait time to 0.5s (current is 0.3s)