### PR TITLE
feat: replace font zoom in/out with scale  

### DIFF
--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -8,6 +8,16 @@ const LanguageSwitcher = ({
 }) => {
   const { ctxIsHebrew } = useContext(FormatContext);
 
+  const updateScaleOrigin = () => {
+    const passageDiv = document.getElementById('selaPassage');
+    if (!passageDiv) {
+      console.error("Can not find the passage division.");
+      return;
+    }
+    // ctxIsHebrew is not updated yet, so reversed origin 
+    passageDiv.style.transformOrigin = ctxIsHebrew ? "0 0" : "100% 0";
+  };
+
   return (
     <div>
       <label
@@ -21,6 +31,7 @@ const LanguageSwitcher = ({
             className="sr-only"
             onChange={() => {
               setLangToHebrew(!ctxIsHebrew);
+              updateScaleOrigin();
             }}
           />
           <div className="block h-10 w-18 lg:w-26 rounded-full bg-meta-9 dark:bg-[#5A616B]"></div>

--- a/src/components/StudyPane/Header/index.tsx
+++ b/src/components/StudyPane/Header/index.tsx
@@ -31,7 +31,7 @@ const Header = ({
     setInfoPaneAction(infoPaneAction);
   }, [infoPaneAction]);
   return (
-    <header className="fixed left-0 top-0 z-9999 flex w-full bg-white">
+    <header id="selaHeader" className="fixed left-0 top-0 z-9999 flex w-full bg-white">
       <div className="flex flex-grow items-center justify-between px-4 py-4 md:px-6 2xl:px-8 border-b-2" style={{borderColor: 'rgb(203 213 225)'}}>
         <div className="flex items-center 2xl:w-2/5 w-1/3">
           <Link className="block flex-shrink-0" href="/">

--- a/src/components/StudyPane/Passage/WordBlock.tsx
+++ b/src/components/StudyPane/Passage/WordBlock.tsx
@@ -24,13 +24,15 @@ const zoomLevelMap: ZoomLevel = {
     12: { fontSize: "text-6xl", verseNumMl: "ml-2.5", verseNumMr: "mr-2.5", hbWidth: "w-42", hbHeight: "h-18", width: "w-72", height: "h-20", fontInPx: "42px", maxWidthPx: 236 },
 }
 
+const DEFAULT_ZOOM_LEVEL = 5;
+
 export const WordBlock = ({
     hebWord
   }: {
     hebWord: HebWord;
   }) => {
   
-    const { ctxZoomLevel, ctxIsHebrew, ctxSelectedWords, ctxSetSelectedWords, 
+    const { ctxIsHebrew, ctxSelectedWords, ctxSetSelectedWords, 
       ctxSelectedHebWords, ctxSetSelectedHebWords, ctxSetNumSelectedWords, 
       ctxNumSelectedWords, ctxSelectedStrophes, ctxColorAction, ctxSelectedColor, 
       ctxSetColorFill, ctxSetBorderColor, ctxSetTextColor, ctxUniformWidth 
@@ -101,10 +103,10 @@ export const WordBlock = ({
   
   
     const verseNumStyles = {
-      className: `${zoomLevelMap[ctxZoomLevel].fontSize} top-0 ${ctxIsHebrew ? 'right-0' : 'left-0'} sups w-1 position-absolute ${ctxIsHebrew ? zoomLevelMap[ctxZoomLevel].verseNumMr : zoomLevelMap[ctxZoomLevel].verseNumMl}`
+      className: `${zoomLevelMap[DEFAULT_ZOOM_LEVEL].fontSize} top-0 ${ctxIsHebrew ? 'right-0' : 'left-0'} sups w-1 position-absolute ${ctxIsHebrew ? zoomLevelMap[DEFAULT_ZOOM_LEVEL].verseNumMr : zoomLevelMap[DEFAULT_ZOOM_LEVEL].verseNumMl}`
     }
   
-    let fontSize = zoomLevelMap[(ctxIsHebrew) ? ctxZoomLevel + 2 : ctxZoomLevel].fontSize;
+    let fontSize = zoomLevelMap[(ctxIsHebrew) ? DEFAULT_ZOOM_LEVEL + 2 : DEFAULT_ZOOM_LEVEL].fontSize;
   
     if (ctxUniformWidth && !ctxIsHebrew) {
       const canvas = document.createElement('canvas');
@@ -112,12 +114,12 @@ export const WordBlock = ({
         // Get the 2D rendering context
         const context = canvas.getContext('2d');
         if (context) {
-          context.font = zoomLevelMap[ctxZoomLevel].fontInPx + " Satoshi";
-          let currentLineCount = wrapText(hebWord.gloss.trim(), context, zoomLevelMap[ctxZoomLevel].maxWidthPx /*(index === 0) ? 90 : 96*/);
-          let currentZoomLevel = ctxZoomLevel - 1;
+          context.font = zoomLevelMap[DEFAULT_ZOOM_LEVEL].fontInPx + " Satoshi";
+          let currentLineCount = wrapText(hebWord.gloss.trim(), context, zoomLevelMap[DEFAULT_ZOOM_LEVEL].maxWidthPx /*(index === 0) ? 90 : 96*/);
+          let currentZoomLevel = DEFAULT_ZOOM_LEVEL - 1;
           while (currentLineCount > 2 && currentZoomLevel >= 0) {
             context.font = zoomLevelMap[currentZoomLevel].fontInPx + " Satoshi";
-            currentLineCount = wrapText(hebWord.gloss.trim(), context, zoomLevelMap[ctxZoomLevel].maxWidthPx);
+            currentLineCount = wrapText(hebWord.gloss.trim(), context, zoomLevelMap[DEFAULT_ZOOM_LEVEL].maxWidthPx);
             fontSize = zoomLevelMap[currentZoomLevel].fontSize;
             currentZoomLevel--;
           }
@@ -127,8 +129,8 @@ export const WordBlock = ({
       }
     }
   
-    const hebBlockSizeStyle = `${zoomLevelMap[ctxZoomLevel].hbWidth} ${zoomLevelMap[ctxZoomLevel].hbHeight}`;
-    const engBlockSizeStyle = `${zoomLevelMap[ctxZoomLevel].width} ${zoomLevelMap[ctxZoomLevel].height} text-wrap`;
+    const hebBlockSizeStyle = `${zoomLevelMap[DEFAULT_ZOOM_LEVEL].hbWidth} ${zoomLevelMap[DEFAULT_ZOOM_LEVEL].hbHeight}`;
+    const engBlockSizeStyle = `${zoomLevelMap[DEFAULT_ZOOM_LEVEL].width} ${zoomLevelMap[DEFAULT_ZOOM_LEVEL].height} text-wrap`;
   
     const renderIndents = (times: number) => {
       return (

--- a/src/components/StudyPane/Passage/WordBlock.tsx
+++ b/src/components/StudyPane/Passage/WordBlock.tsx
@@ -32,7 +32,7 @@ export const WordBlock = ({
     hebWord: HebWord;
   }) => {
   
-    const { ctxZoomLevel, ctxIsHebrew, ctxUniformWidth,
+    const { ctxIsHebrew, ctxUniformWidth,
       ctxSelectedHebWords, ctxSetSelectedHebWords, ctxSetNumSelectedWords, 
       ctxSetSelectedStrophes, ctxColorAction, ctxSelectedColor, 
       ctxSetColorFill, ctxSetBorderColor, ctxSetTextColor

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -11,7 +11,6 @@ const Passage = ({
 }: {
   content: PassageData;
 }) => {
-
   const { ctxSelectedHebWords, ctxSetSelectedHebWords, ctxSetNumSelectedWords, ctxSetSelectedStrophes,
     ctxSetColorFill, ctxSetBorderColor, ctxSetTextColor, ctxStructureUpdateType, ctxSetStructureUpdateType, ctxSetStropheCount
   } = useContext(FormatContext)
@@ -174,7 +173,6 @@ const Passage = ({
 
   return (
     <main className="relative top-19 h-0">
-      
       <div
         key={`passage`}
         onMouseDown={handleMouseDown}
@@ -183,7 +181,6 @@ const Passage = ({
         {...passageContentStyle}
         className="h-0"
       >
-
         <div id="selaPassage" className='relative py-5 top-5 z-10 overflow-hidden'>
           {
             passageData.strophes.map((strophe)=>{

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -181,7 +181,7 @@ const Passage = ({
         {...passageContentStyle}
         className="h-0"
       >
-        <div id="selaPassage" className='relative py-5 top-5 z-10 overflow-hidden'>
+        <div id="selaPassage" className='relative top-16 pb-2 z-10 overflow-hidden'>
           {
             passageData.strophes.map((strophe)=>{
               return(

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -38,7 +38,7 @@ const Passage = ({
     document.addEventListener('mouseup', handleMouseUp);
     setSelectionStart({ x: event.clientX + window.scrollX, y: event.clientY + window.scrollY });
     setSelectionEnd(null);
-
+    
 
     //click to de-select
     //if clicked on wordBlock, set status here so de-select function doesnt fire
@@ -134,7 +134,6 @@ const Passage = ({
     const top = Math.min(selectionStart.y, selectionEnd.y) - window.scrollY;
     const width = Math.abs(selectionStart.x - selectionEnd.x);
     const height = Math.abs(selectionStart.y - selectionEnd.y);
-    console.log(`height is ${height}, width is ${width}`);
     return {
       left,
       top,
@@ -144,6 +143,7 @@ const Passage = ({
       backgroundColor: 'rgba(0, 0, 255, 0.2)',
       border: '1px solid blue',
       pointerEvents: 'none',
+      zIndex: 100,
     };
   };
 
@@ -189,8 +189,8 @@ const Passage = ({
         {...passageContentStyle}
         className="h-0"
       >
-        <div className="h-12"/>
-        <div id="selaPassage" className='relative py-5 top-8 z-10 overflow-hidden'>
+        <div className="h-16"/>
+        <div id="selaPassage" className='relative z-10 overflow-hidden'>
           {
             passageData.strophes.map((strophe)=>{
               return(
@@ -201,8 +201,8 @@ const Passage = ({
               )
             })
           }
-          {isDragging && <div style={getSelectionBoxStyle()} />}
         </div>
+        {isDragging && <div style={getSelectionBoxStyle()} />}
       </div>
 
     </main>

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -177,16 +177,18 @@ const Passage = ({
   }
 
   return (
-    <main className="relative top-19">
-    
+    <main className="relative top-19 h-0">
+      
       <div
         key={`passage`}
         onMouseDown={handleMouseDown}
         ref={containerRef}
         style={{ userSelect: 'none' }}
         {...passageContentStyle}
+        className="h-0"
       >
-        <div className='relative top-8 z-10 overflow-hidden'>
+        <div className="h-12"/>
+        <div id="selaPassage" className='relative z-10 overflow-hidden'>
           {
             passageData.strophes.map((strophe)=>{
               return(

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -318,8 +318,6 @@ export const StropheActionBtn = ({ stropheAction, toolTip } : {stropheAction : S
   const handleClick = () => { buttonEnabled && ctxSetStropheAction(stropheAction) };
 
   return (
-    <>
-    <div className="relative">
     <div className="flex flex-col group relative inline-block items-center justify-center px-2 xsm:flex-row">
       <button
         className="hover:text-primary"
@@ -336,8 +334,6 @@ export const StropheActionBtn = ({ stropheAction, toolTip } : {stropheAction : S
         <ToolTip text={toolTip} />
       </button>
     </div>
-    </div>
-    </>
   );
 };
 

--- a/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
+++ b/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
@@ -102,8 +102,7 @@ const ScaleDropDown = ({setScaleValue}: {
       const headerHeight = document.getElementById("selaHeader")?.offsetHeight;
       const hardcodedPadding = 64; // <div class="top-16">;
       const fitScreenHeight = window.innerHeight - (headerHeight || 0) -  hardcodedPadding;
-      const scale = Number((currentHeight ? fitScreenHeight / currentHeight : 1).toFixed(2));
-
+      const scale = Number((currentHeight ? fitScreenHeight / currentHeight : 1).toPrecision(2));
       setScaleValueAndScalePassage(scale);
       setDisplayScaleLevel("Fit");
       setFitScreen(true);

--- a/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
+++ b/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
@@ -1,11 +1,14 @@
-import React, { ChangeEvent, useState, useRef, useEffect } from "react";
+import React, { useContext, useState, useRef, useEffect } from "react";
+import { FormatContext } from '../index';
 
-const ScaleDropDown: React.FC = () => {
-  const [scaleLevel, setScaleLevel] = useState(1);
+const ScaleDropDown = ({setScaleValue}: {
+  setScaleValue:(value:number) => void;
+}) => {
+  const { ctxIsHebrew, ctxScaleValue } = useContext(FormatContext);
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [fitScreen, setFitScreen] = useState(false);
-  const [displayScaleLevel, setDisplayScaleLevel] = useState("100%"); 
+  const [displayScaleLevel, setDisplayScaleLevel] = useState(`${ctxScaleValue * 100}%`); 
 
   const trigger = useRef<any>(null);
   const dropdown = useRef<any>(null);
@@ -13,7 +16,7 @@ const ScaleDropDown: React.FC = () => {
   const PRESET_SCALE_LEVELS:[number,string][] = [[0.5, '50%'], [0.75, '75%'], [0.9, '90%'], 
         [1, '100%'], [1.25, '125%'], [1.5, '150%'], [2, '200%']];
 
-  // close on click outside
+  // close dropdown on click outside
   useEffect(() => {
     const clickHandler = ({ target }: MouseEvent) => {
       if (!dropdown.current) return;
@@ -29,7 +32,7 @@ const ScaleDropDown: React.FC = () => {
     return () => document.removeEventListener("click", clickHandler);
   });
 
-  // close if the esc key is pressed
+  // close dropdown if the esc key is pressed
   useEffect(() => {
     const keyHandler = ({ keyCode }: KeyboardEvent) => {
       if (!dropdownOpen || keyCode !== 27) return;
@@ -43,103 +46,124 @@ const ScaleDropDown: React.FC = () => {
   useEffect(() => {
     const keyHandler = ({ keyCode }: KeyboardEvent) => {
       if (keyCode !== 13) return;
-      updateInputScaleLevel();
+      scaleByInput();
       setDropdownOpen(false);
     };
     document.addEventListener("keydown", keyHandler);
     return () => document.removeEventListener("keydown", keyHandler);
   });
 
-  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setDisplayScaleLevel(event.target.value);
+  const setScaleValueAndScalePassage = (scale:number) => {
+    setScaleValue(scale);
+    const passageDiv = document.getElementById('selaPassage');
+    if (!passageDiv) {
+      console.error("Can not find the passage division.");
+      return;
+    }
+    passageDiv.style.height = `${passageDiv.offsetHeight * scale}`;
+    passageDiv.style.transform = `scale(${scale})`;
+    passageDiv.style.transformOrigin = ctxIsHebrew ? "100% 0": "0 0";
   };
 
-  const updateInputScaleLevel = () => {
-    // update scale level with user input value
+  // scale passage by user input value
+  const scaleByInput = () => {
     let scale = parseInt(displayScaleLevel) / 100;
+    if (isNaN(scale)) {
+      setDisplayScaleLevel(`${ctxScaleValue * 100}%`);
+      return;
+    } 
     scale = scale < 0.5 ? 0.5 : (scale > 2 ? 2 : scale);
-    setScaleLevel(scale);
-    
+    setScaleValueAndScalePassage(scale);
+
     setDisplayScaleLevel(`${scale * 100}%`);
-    document.getElementById("scale-input")?.blur();
+    document.getElementById("scaleInput")?.blur();
     fitScreen && setFitScreen(false);
     setDropdownOpen(false);
   }
 
-  const handleScaleLevelSelect = (presetScale:number, presetScaleDisplay:string) => {
-    setScaleLevel(presetScale);
+  const scaleByPresetLevel = (presetScale:number, presetScaleDisplay:string) => {
+    setScaleValueAndScalePassage(presetScale);
     setDisplayScaleLevel(presetScaleDisplay);
     fitScreen && setFitScreen(false);
     setDropdownOpen(false)
   }
 
-  const ScaleToFitScreen = () => {
-    // calculate fit screen scale
-    
-    setFitScreen(true);
+  const ScaleByFitScreen = () => {
+    if (!fitScreen) {
+      /*TODO: current layout is not steady, may need to update the calculation later */
+      // calculate fit screen height
+      const currentHeight = document.getElementById('selaPassage')?.offsetHeight;
+      const headerHeight = document.getElementById("selaHeader")?.offsetHeight;
+      const toolbarHeight = document.getElementById("selaToolbar")?.offsetHeight;
+      const fitScreenHeight = window.innerHeight - (headerHeight || 0) -  (toolbarHeight || 0);
+      const scale = currentHeight ? fitScreenHeight / currentHeight : 1;
+
+      setScaleValueAndScalePassage(scale);
+      setDisplayScaleLevel("Fit");
+      setFitScreen(true);
+    }
+    setDropdownOpen(false);
   };
 
   return (
-        <div className="relative inline-block">
-          <div
-            ref={trigger}
-            onClick={() => setDropdownOpen(!dropdownOpen)}
-            className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-3 py-2 font-medium"
-          >
-            <input id="scale-input" 
-              type="text" 
-              value={displayScaleLevel}
-              onChange={handleInputChange}
-              className="w-16 border-r">
-            </input>
-            <svg
-              className={`fill-current duration-200 ease-linear ${
-                dropdownOpen && "rotate-180"
-              }`}
-              width="12"
-              height="7"
-              viewBox="0 0 12 7"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M0.564864 0.879232C0.564864 0.808624 0.600168 0.720364 0.653125 0.667408C0.776689 0.543843 0.970861 0.543844 1.09443 0.649756L5.82517 5.09807C5.91343 5.18633 6.07229 5.18633 6.17821 5.09807L10.9089 0.649756C11.0325 0.526192 11.2267 0.543844 11.3502 0.667408C11.4738 0.790972 11.4562 0.985145 11.3326 1.10871L6.60185 5.55702C6.26647 5.85711 5.73691 5.85711 5.41917 5.55702L0.670776 1.10871C0.600168 1.0381 0.564864 0.967492 0.564864 0.879232Z"
-                fill=""
-              />
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M1.4719 0.229332L6.00169 4.48868L10.5171 0.24288C10.9015 -0.133119 11.4504 -0.0312785 11.7497 0.267983C12.1344 0.652758 12.0332 1.2069 11.732 1.50812L11.7197 1.52041L6.97862 5.9781C6.43509 6.46442 5.57339 6.47872 5.03222 5.96853C5.03192 5.96825 5.03252 5.96881 5.03222 5.96853L0.271144 1.50833C0.123314 1.3605 -5.04223e-08 1.15353 -3.84322e-08 0.879226C-2.88721e-08 0.660517 0.0936127 0.428074 0.253705 0.267982C0.593641 -0.0719548 1.12269 -0.0699964 1.46204 0.220873L1.4719 0.229332ZM5.41917 5.55702C5.73691 5.85711 6.26647 5.85711 6.60185 5.55702L11.3326 1.10871C11.4562 0.985145 11.4738 0.790972 11.3502 0.667408C11.2267 0.543844 11.0325 0.526192 10.9089 0.649756L6.17821 5.09807C6.07229 5.18633 5.91343 5.18633 5.82517 5.09807L1.09443 0.649756C0.970861 0.543844 0.776689 0.543843 0.653125 0.667408C0.600168 0.720364 0.564864 0.808624 0.564864 0.879232C0.564864 0.967492 0.600168 1.0381 0.670776 1.10871L5.41917 5.55702Z"
-                fill=""
-              />
-            </svg>
-          </div>  
-          <div
-            ref={dropdown}
-            onFocus={() => setDropdownOpen(true)}
-            onBlur={() => setDropdownOpen(false)}
-            className={`absolute left-0 top-full z-40 mt-2 w-full rounded-md border border-stroke bg-white py-3 shadow-card ${
-              dropdownOpen === true ? "block" : "hidden"
-            }`}
-          >
-            <ul className="flex flex-col">
-                <li 
-                  className="flex cursor=pointer  px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
-                  onClick={()=>ScaleToFitScreen()}
-                > Fit
-                </li>
-                <hr/>
-                {
-                    PRESET_SCALE_LEVELS.map( scalePair =>
-                        (<li className="flex cursor=pointer px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
-                          onClick={()=> handleScaleLevelSelect(...scalePair)}>
-                            {scalePair[1]}
-                        </li>)
-                    )
-                }
-            </ul>
-          </div>
-        </div>
+    <div className="relative inline-block">
+      <div
+        ref={trigger}
+        onClick={() => setDropdownOpen(!dropdownOpen)}
+        className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-3 py-2 font-medium"
+      >
+        <input id="scaleInput" 
+          type="text" 
+          value={displayScaleLevel}
+          onChange={e => setDisplayScaleLevel(e.target.value)}
+          className="w-16 border-r">
+        </input>
+        <svg
+          className={`fill-current duration-200 ease-linear ${
+            dropdownOpen && "rotate-180"
+          }`}
+          width="12"
+          height="7"
+          viewBox="0 0 12 7"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0.564864 0.879232C0.564864 0.808624 0.600168 0.720364 0.653125 0.667408C0.776689 0.543843 0.970861 0.543844 1.09443 0.649756L5.82517 5.09807C5.91343 5.18633 6.07229 5.18633 6.17821 5.09807L10.9089 0.649756C11.0325 0.526192 11.2267 0.543844 11.3502 0.667408C11.4738 0.790972 11.4562 0.985145 11.3326 1.10871L6.60185 5.55702C6.26647 5.85711 5.73691 5.85711 5.41917 5.55702L0.670776 1.10871C0.600168 1.0381 0.564864 0.967492 0.564864 0.879232Z"
+            fill=""
+          />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M1.4719 0.229332L6.00169 4.48868L10.5171 0.24288C10.9015 -0.133119 11.4504 -0.0312785 11.7497 0.267983C12.1344 0.652758 12.0332 1.2069 11.732 1.50812L11.7197 1.52041L6.97862 5.9781C6.43509 6.46442 5.57339 6.47872 5.03222 5.96853C5.03192 5.96825 5.03252 5.96881 5.03222 5.96853L0.271144 1.50833C0.123314 1.3605 -5.04223e-08 1.15353 -3.84322e-08 0.879226C-2.88721e-08 0.660517 0.0936127 0.428074 0.253705 0.267982C0.593641 -0.0719548 1.12269 -0.0699964 1.46204 0.220873L1.4719 0.229332ZM5.41917 5.55702C5.73691 5.85711 6.26647 5.85711 6.60185 5.55702L11.3326 1.10871C11.4562 0.985145 11.4738 0.790972 11.3502 0.667408C11.2267 0.543844 11.0325 0.526192 10.9089 0.649756L6.17821 5.09807C6.07229 5.18633 5.91343 5.18633 5.82517 5.09807L1.09443 0.649756C0.970861 0.543844 0.776689 0.543843 0.653125 0.667408C0.600168 0.720364 0.564864 0.808624 0.564864 0.879232C0.564864 0.967492 0.600168 1.0381 0.670776 1.10871L5.41917 5.55702Z"
+            fill=""
+          />
+        </svg>
+      </div>  
+      <div
+        ref={dropdown}
+        onFocus={() => setDropdownOpen(true)}
+        onBlur={() => setDropdownOpen(false)}
+        className={`absolute left-0 top-full z-40 mt-2 w-full rounded-md border border-stroke bg-white py-3 shadow-card ${
+          dropdownOpen === true ? "block" : "hidden"
+        }`}
+      >
+        <ul className="flex flex-col">
+          <li 
+            className="flex cursor=pointer  px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+            onClick={()=> ScaleByFitScreen()}
+          > Fit
+          </li>
+          <hr/>
+          {PRESET_SCALE_LEVELS.map( scalePair =>
+            (<li className="flex cursor=pointer px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+              key={scalePair[1]} onClick={()=> scaleByPresetLevel(...scalePair)}>
+                {scalePair[1]}
+            </li>)
+          )}
+        </ul>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
+++ b/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
@@ -94,8 +94,8 @@ const ScaleDropDown = ({setScaleValue}: {
       // calculate fit screen height
       const currentHeight = document.getElementById('selaPassage')?.offsetHeight;
       const headerHeight = document.getElementById("selaHeader")?.offsetHeight;
-      const toolbarHeight = document.getElementById("selaToolbar")?.offsetHeight;
-      const fitScreenHeight = window.innerHeight - (headerHeight || 0) -  (toolbarHeight || 0);
+      const hardcodedPadding = 64; // <div class="h-16">;
+      const fitScreenHeight = window.innerHeight - (headerHeight || 0) -  hardcodedPadding;
       const scale = currentHeight ? fitScreenHeight / currentHeight : 1;
 
       setScaleValueAndScalePassage(scale);
@@ -110,13 +110,13 @@ const ScaleDropDown = ({setScaleValue}: {
       <div
         ref={trigger}
         onClick={() => setDropdownOpen(!dropdownOpen)}
-        className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-3 py-2 font-medium"
+        className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-2 py-1.5 font-medium text-sm"
       >
         <input id="scaleInput" 
           type="text" 
           value={displayScaleLevel}
           onChange={e => setDisplayScaleLevel(e.target.value)}
-          className="w-16 border-r">
+          className="w-12 border-r">
         </input>
         <svg
           className={`fill-current duration-200 ease-linear ${
@@ -150,13 +150,13 @@ const ScaleDropDown = ({setScaleValue}: {
       >
         <ul className="flex flex-col">
           <li 
-            className="flex cursor=pointer  px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+            className="flex cursor=pointer  px-5 py-2 font-normal text-sm select-none hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
             onClick={()=> ScaleByFitScreen()}
           > Fit
           </li>
           <hr/>
           {PRESET_SCALE_LEVELS.map( scalePair =>
-            (<li className="flex cursor=pointer px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+            (<li className="flex cursor=pointer px-5 py-2 font-normal text-sm select-none hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
               key={scalePair[1]} onClick={()=> scaleByPresetLevel(...scalePair)}>
                 {scalePair[1]}
             </li>)

--- a/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
+++ b/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
@@ -100,9 +100,9 @@ const ScaleDropDown = ({setScaleValue}: {
       // calculate fit screen height
       const currentHeight = document.getElementById('selaPassage')?.offsetHeight;
       const headerHeight = document.getElementById("selaHeader")?.offsetHeight;
-      const hardcodedPadding = 64; // <div class="h-16">;
+      const hardcodedPadding = 64; // <div class="top-16">;
       const fitScreenHeight = window.innerHeight - (headerHeight || 0) -  hardcodedPadding;
-      const scale = currentHeight ? fitScreenHeight / currentHeight : 1;
+      const scale = Number((currentHeight ? fitScreenHeight / currentHeight : 1).toFixed(2));
 
       setScaleValueAndScalePassage(scale);
       setDisplayScaleLevel("Fit");

--- a/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
+++ b/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
@@ -1,5 +1,7 @@
 import React, { useContext, useState, useRef, useEffect } from "react";
 import { FormatContext } from '../index';
+import {PiMinusSquare, PiPlusSquare } from "react-icons/pi";
+import { ToolTip } from "./Buttons";
 
 const ScaleDropDown = ({setScaleValue}: {
   setScaleValue:(value:number) => void;
@@ -13,8 +15,8 @@ const ScaleDropDown = ({setScaleValue}: {
   const trigger = useRef<any>(null);
   const dropdown = useRef<any>(null);
 
-  const PRESET_SCALE_LEVELS:[number,string][] = [[0.5, '50%'], [0.75, '75%'], [0.9, '90%'], 
-        [1, '100%'], [1.25, '125%'], [1.5, '150%'], [2, '200%']];
+  const PRESET_SCALE_LEVELS:[number,string][] = [[0.25, '25%'], [0.5, '50%'], [0.75, '75%'],
+        [0.9, '90%'], [1, '100%'], [1.25, '125%'], [1.5, '150%'], [2, '200%']];
 
   // close dropdown on click outside
   useEffect(() => {
@@ -60,6 +62,9 @@ const ScaleDropDown = ({setScaleValue}: {
       console.error("Can not find the passage division.");
       return;
     }
+    if (scale >= 1) { // override the width of the passage to avoid
+      passageDiv.style.width = `${Math.round(1/scale*100)}%`;  
+    }
     passageDiv.style.height = `${passageDiv.offsetHeight * scale}`;
     passageDiv.style.transform = `scale(${scale})`;
     passageDiv.style.transformOrigin = ctxIsHebrew ? "100% 0": "0 0";
@@ -67,12 +72,12 @@ const ScaleDropDown = ({setScaleValue}: {
 
   // scale passage by user input value
   const scaleByInput = () => {
-    let scale = parseInt(displayScaleLevel) / 100;
+    let scale = Math.round(Number(displayScaleLevel)) / 100;
     if (isNaN(scale)) {
       setDisplayScaleLevel(`${ctxScaleValue * 100}%`);
       return;
     } 
-    scale = scale < 0.5 ? 0.5 : (scale > 2 ? 2 : scale);
+    scale = scale < 0.25 ? 0.25 : (scale > 2 ? 2 : scale);
     setScaleValueAndScalePassage(scale);
 
     setDisplayScaleLevel(`${scale * 100}%`);
@@ -88,6 +93,7 @@ const ScaleDropDown = ({setScaleValue}: {
     setDropdownOpen(false)
   }
 
+  // scale passage to horiztontally fit to screen
   const ScaleByFitScreen = () => {
     if (!fitScreen) {
       /*TODO: current layout is not steady, may need to update the calculation later */
@@ -105,63 +111,104 @@ const ScaleDropDown = ({setScaleValue}: {
     setDropdownOpen(false);
   };
 
+  const scaleByDecrement = () => {
+    if (ctxScaleValue <= 0.25) return;
+    const targetValue = ctxScaleValue - 0.05 > 0.25 ? ctxScaleValue - 0.05 : 0.25; 
+    setScaleValueAndScalePassage(targetValue);
+    setDisplayScaleLevel(`${Math.round(targetValue * 100)}%`);
+    fitScreen && setFitScreen(false);
+    setDropdownOpen(false)
+  }
+
+  const scaleByIncrement = () => {
+    if (ctxScaleValue >= 2) return;
+    const targetValue = ctxScaleValue + 0.05 < 2 ? ctxScaleValue + 0.05 : 2; 
+    setScaleValueAndScalePassage(targetValue);
+    setDisplayScaleLevel(`${Math.round(targetValue * 100)}%`);
+    fitScreen && setFitScreen(false);
+    setDropdownOpen(false)
+  }
+
   return (
-    <div className="relative inline-block">
-      <div
-        ref={trigger}
-        onClick={() => setDropdownOpen(!dropdownOpen)}
-        className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-2 py-1.5 font-medium text-sm"
-      >
-        <input id="scaleInput" 
-          type="text" 
-          value={displayScaleLevel}
-          onChange={e => setDisplayScaleLevel(e.target.value)}
-          className="w-12 border-r">
-        </input>
-        <svg
-          className={`fill-current duration-200 ease-linear ${
-            dropdownOpen && "rotate-180"
-          }`}
-          width="12"
-          height="7"
-          viewBox="0 0 12 7"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
+    <div className="flex">
+      {/* minus scale button */}
+      <div className="flex flex-col group relative inline-block items-center justify-center px-1 dark:border-strokedark xsm:flex-row">
+        <button
+          className="hover:text-primary"
+          onClick={scaleByDecrement}>
+          <PiMinusSquare  fontSize="1.5em" />
+        </button>
+        <ToolTip text="Minus scale by 5%"/>
+      </div>
+
+      {/* scale input & dropdown */}
+      <div className="relative flex-col inline-block">
+        <div
+          ref={trigger}
+          onClick={() => setDropdownOpen(!dropdownOpen)}
+          className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-2 py-1.5 font-medium text-sm"
         >
-          <path
-            d="M0.564864 0.879232C0.564864 0.808624 0.600168 0.720364 0.653125 0.667408C0.776689 0.543843 0.970861 0.543844 1.09443 0.649756L5.82517 5.09807C5.91343 5.18633 6.07229 5.18633 6.17821 5.09807L10.9089 0.649756C11.0325 0.526192 11.2267 0.543844 11.3502 0.667408C11.4738 0.790972 11.4562 0.985145 11.3326 1.10871L6.60185 5.55702C6.26647 5.85711 5.73691 5.85711 5.41917 5.55702L0.670776 1.10871C0.600168 1.0381 0.564864 0.967492 0.564864 0.879232Z"
-            fill=""
-          />
-          <path
-            fillRule="evenodd"
-            clipRule="evenodd"
-            d="M1.4719 0.229332L6.00169 4.48868L10.5171 0.24288C10.9015 -0.133119 11.4504 -0.0312785 11.7497 0.267983C12.1344 0.652758 12.0332 1.2069 11.732 1.50812L11.7197 1.52041L6.97862 5.9781C6.43509 6.46442 5.57339 6.47872 5.03222 5.96853C5.03192 5.96825 5.03252 5.96881 5.03222 5.96853L0.271144 1.50833C0.123314 1.3605 -5.04223e-08 1.15353 -3.84322e-08 0.879226C-2.88721e-08 0.660517 0.0936127 0.428074 0.253705 0.267982C0.593641 -0.0719548 1.12269 -0.0699964 1.46204 0.220873L1.4719 0.229332ZM5.41917 5.55702C5.73691 5.85711 6.26647 5.85711 6.60185 5.55702L11.3326 1.10871C11.4562 0.985145 11.4738 0.790972 11.3502 0.667408C11.2267 0.543844 11.0325 0.526192 10.9089 0.649756L6.17821 5.09807C6.07229 5.18633 5.91343 5.18633 5.82517 5.09807L1.09443 0.649756C0.970861 0.543844 0.776689 0.543843 0.653125 0.667408C0.600168 0.720364 0.564864 0.808624 0.564864 0.879232C0.564864 0.967492 0.600168 1.0381 0.670776 1.10871L5.41917 5.55702Z"
-            fill=""
-          />
-        </svg>
-      </div>  
-      <div
-        ref={dropdown}
-        onFocus={() => setDropdownOpen(true)}
-        onBlur={() => setDropdownOpen(false)}
-        className={`absolute left-0 top-full z-40 mt-2 w-full rounded-md border border-stroke bg-white py-3 shadow-card ${
-          dropdownOpen === true ? "block" : "hidden"
-        }`}
-      >
-        <ul className="flex flex-col">
-          <li 
-            className="flex cursor=pointer  px-5 py-2 font-normal text-sm select-none hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
-            onClick={()=> ScaleByFitScreen()}
-          > Fit
-          </li>
-          <hr/>
-          {PRESET_SCALE_LEVELS.map( scalePair =>
-            (<li className="flex cursor=pointer px-5 py-2 font-normal text-sm select-none hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
-              key={scalePair[1]} onClick={()=> scaleByPresetLevel(...scalePair)}>
-                {scalePair[1]}
-            </li>)
-          )}
-        </ul>
+          <input id="scaleInput" 
+            type="text" 
+            value={displayScaleLevel}
+            onChange={e => setDisplayScaleLevel(e.target.value)}
+            className="w-12 border-r">
+          </input>
+          <svg
+            className={`fill-current duration-200 ease-linear ${
+              dropdownOpen && "rotate-180"
+            }`}
+            width="12"
+            height="7"
+            viewBox="0 0 12 7"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0.564864 0.879232C0.564864 0.808624 0.600168 0.720364 0.653125 0.667408C0.776689 0.543843 0.970861 0.543844 1.09443 0.649756L5.82517 5.09807C5.91343 5.18633 6.07229 5.18633 6.17821 5.09807L10.9089 0.649756C11.0325 0.526192 11.2267 0.543844 11.3502 0.667408C11.4738 0.790972 11.4562 0.985145 11.3326 1.10871L6.60185 5.55702C6.26647 5.85711 5.73691 5.85711 5.41917 5.55702L0.670776 1.10871C0.600168 1.0381 0.564864 0.967492 0.564864 0.879232Z"
+              fill=""
+            />
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M1.4719 0.229332L6.00169 4.48868L10.5171 0.24288C10.9015 -0.133119 11.4504 -0.0312785 11.7497 0.267983C12.1344 0.652758 12.0332 1.2069 11.732 1.50812L11.7197 1.52041L6.97862 5.9781C6.43509 6.46442 5.57339 6.47872 5.03222 5.96853C5.03192 5.96825 5.03252 5.96881 5.03222 5.96853L0.271144 1.50833C0.123314 1.3605 -5.04223e-08 1.15353 -3.84322e-08 0.879226C-2.88721e-08 0.660517 0.0936127 0.428074 0.253705 0.267982C0.593641 -0.0719548 1.12269 -0.0699964 1.46204 0.220873L1.4719 0.229332ZM5.41917 5.55702C5.73691 5.85711 6.26647 5.85711 6.60185 5.55702L11.3326 1.10871C11.4562 0.985145 11.4738 0.790972 11.3502 0.667408C11.2267 0.543844 11.0325 0.526192 10.9089 0.649756L6.17821 5.09807C6.07229 5.18633 5.91343 5.18633 5.82517 5.09807L1.09443 0.649756C0.970861 0.543844 0.776689 0.543843 0.653125 0.667408C0.600168 0.720364 0.564864 0.808624 0.564864 0.879232C0.564864 0.967492 0.600168 1.0381 0.670776 1.10871L5.41917 5.55702Z"
+              fill=""
+            />
+          </svg>
+        </div>  
+        <div
+          ref={dropdown}
+          onFocus={() => setDropdownOpen(true)}
+          onBlur={() => setDropdownOpen(false)}
+          className={`absolute left-0 top-full z-40 mt-2 w-full rounded-md border border-stroke bg-white py-3 shadow-card ${
+            dropdownOpen === true ? "block" : "hidden"
+          }`}
+        >
+          <ul className="flex flex-col">
+            <li 
+              className="flex cursor=pointer  px-5 py-2 font-normal text-sm select-none hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+              onClick={()=> ScaleByFitScreen()}
+            > Fit
+            </li>
+            <hr/>
+            {PRESET_SCALE_LEVELS.map( scalePair =>
+              (<li className="flex cursor=pointer px-5 py-2 font-normal text-sm select-none hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+                key={scalePair[1]} onClick={()=> scaleByPresetLevel(...scalePair)}>
+                  {scalePair[1]}
+              </li>)
+            )}
+          </ul>
+        </div>
+      </div>
+    
+      {/* add scale button */}
+      <div className="flex flex-col group relative inline-block items-center justify-center px-1 dark:border-strokedark xsm:flex-row">
+        <button
+          className="hover:text-primary"
+          onClick={scaleByIncrement}>
+          <PiPlusSquare fontSize="1.5em" />
+        </button>
+        <ToolTip text="Add scale by 5%"/>
       </div>
     </div>
   );

--- a/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
+++ b/src/components/StudyPane/Toolbar/ScaleDropDown.tsx
@@ -1,0 +1,146 @@
+import React, { ChangeEvent, useState, useRef, useEffect } from "react";
+
+const ScaleDropDown: React.FC = () => {
+  const [scaleLevel, setScaleLevel] = useState(1);
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [fitScreen, setFitScreen] = useState(false);
+  const [displayScaleLevel, setDisplayScaleLevel] = useState("100%"); 
+
+  const trigger = useRef<any>(null);
+  const dropdown = useRef<any>(null);
+
+  const PRESET_SCALE_LEVELS:[number,string][] = [[0.5, '50%'], [0.75, '75%'], [0.9, '90%'], 
+        [1, '100%'], [1.25, '125%'], [1.5, '150%'], [2, '200%']];
+
+  // close on click outside
+  useEffect(() => {
+    const clickHandler = ({ target }: MouseEvent) => {
+      if (!dropdown.current) return;
+      if (
+        !dropdownOpen ||
+        dropdown.current.contains(target) ||
+        trigger.current.contains(target)
+      )
+        return;
+      setDropdownOpen(false);
+    };
+    document.addEventListener("click", clickHandler);
+    return () => document.removeEventListener("click", clickHandler);
+  });
+
+  // close if the esc key is pressed
+  useEffect(() => {
+    const keyHandler = ({ keyCode }: KeyboardEvent) => {
+      if (!dropdownOpen || keyCode !== 27) return;
+      setDropdownOpen(false);
+    };
+    document.addEventListener("keydown", keyHandler);
+    return () => document.removeEventListener("keydown", keyHandler);
+  });
+
+  // update input scale if the enter key is pressed
+  useEffect(() => {
+    const keyHandler = ({ keyCode }: KeyboardEvent) => {
+      if (keyCode !== 13) return;
+      updateInputScaleLevel();
+      setDropdownOpen(false);
+    };
+    document.addEventListener("keydown", keyHandler);
+    return () => document.removeEventListener("keydown", keyHandler);
+  });
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setDisplayScaleLevel(event.target.value);
+  };
+
+  const updateInputScaleLevel = () => {
+    // update scale level with user input value
+    let scale = parseInt(displayScaleLevel) / 100;
+    scale = scale < 0.5 ? 0.5 : (scale > 2 ? 2 : scale);
+    setScaleLevel(scale);
+    
+    setDisplayScaleLevel(`${scale * 100}%`);
+    document.getElementById("scale-input")?.blur();
+    fitScreen && setFitScreen(false);
+    setDropdownOpen(false);
+  }
+
+  const handleScaleLevelSelect = (presetScale:number, presetScaleDisplay:string) => {
+    setScaleLevel(presetScale);
+    setDisplayScaleLevel(presetScaleDisplay);
+    fitScreen && setFitScreen(false);
+    setDropdownOpen(false)
+  }
+
+  const ScaleToFitScreen = () => {
+    // calculate fit screen scale
+    
+    setFitScreen(true);
+  };
+
+  return (
+        <div className="relative inline-block">
+          <div
+            ref={trigger}
+            onClick={() => setDropdownOpen(!dropdownOpen)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-stroke px-3 py-2 font-medium"
+          >
+            <input id="scale-input" 
+              type="text" 
+              value={displayScaleLevel}
+              onChange={handleInputChange}
+              className="w-16 border-r">
+            </input>
+            <svg
+              className={`fill-current duration-200 ease-linear ${
+                dropdownOpen && "rotate-180"
+              }`}
+              width="12"
+              height="7"
+              viewBox="0 0 12 7"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0.564864 0.879232C0.564864 0.808624 0.600168 0.720364 0.653125 0.667408C0.776689 0.543843 0.970861 0.543844 1.09443 0.649756L5.82517 5.09807C5.91343 5.18633 6.07229 5.18633 6.17821 5.09807L10.9089 0.649756C11.0325 0.526192 11.2267 0.543844 11.3502 0.667408C11.4738 0.790972 11.4562 0.985145 11.3326 1.10871L6.60185 5.55702C6.26647 5.85711 5.73691 5.85711 5.41917 5.55702L0.670776 1.10871C0.600168 1.0381 0.564864 0.967492 0.564864 0.879232Z"
+                fill=""
+              />
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M1.4719 0.229332L6.00169 4.48868L10.5171 0.24288C10.9015 -0.133119 11.4504 -0.0312785 11.7497 0.267983C12.1344 0.652758 12.0332 1.2069 11.732 1.50812L11.7197 1.52041L6.97862 5.9781C6.43509 6.46442 5.57339 6.47872 5.03222 5.96853C5.03192 5.96825 5.03252 5.96881 5.03222 5.96853L0.271144 1.50833C0.123314 1.3605 -5.04223e-08 1.15353 -3.84322e-08 0.879226C-2.88721e-08 0.660517 0.0936127 0.428074 0.253705 0.267982C0.593641 -0.0719548 1.12269 -0.0699964 1.46204 0.220873L1.4719 0.229332ZM5.41917 5.55702C5.73691 5.85711 6.26647 5.85711 6.60185 5.55702L11.3326 1.10871C11.4562 0.985145 11.4738 0.790972 11.3502 0.667408C11.2267 0.543844 11.0325 0.526192 10.9089 0.649756L6.17821 5.09807C6.07229 5.18633 5.91343 5.18633 5.82517 5.09807L1.09443 0.649756C0.970861 0.543844 0.776689 0.543843 0.653125 0.667408C0.600168 0.720364 0.564864 0.808624 0.564864 0.879232C0.564864 0.967492 0.600168 1.0381 0.670776 1.10871L5.41917 5.55702Z"
+                fill=""
+              />
+            </svg>
+          </div>  
+          <div
+            ref={dropdown}
+            onFocus={() => setDropdownOpen(true)}
+            onBlur={() => setDropdownOpen(false)}
+            className={`absolute left-0 top-full z-40 mt-2 w-full rounded-md border border-stroke bg-white py-3 shadow-card ${
+              dropdownOpen === true ? "block" : "hidden"
+            }`}
+          >
+            <ul className="flex flex-col">
+                <li 
+                  className="flex cursor=pointer  px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+                  onClick={()=>ScaleToFitScreen()}
+                > Fit
+                </li>
+                <hr/>
+                {
+                    PRESET_SCALE_LEVELS.map( scalePair =>
+                        (<li className="flex cursor=pointer px-5 py-2 font-medium hover:bg-whiter hover:text-primary dark:hover:bg-meta-4"
+                          onClick={()=> handleScaleLevelSelect(...scalePair)}>
+                            {scalePair[1]}
+                        </li>)
+                    )
+                }
+            </ul>
+          </div>
+        </div>
+  );
+};
+
+export default ScaleDropDown;

--- a/src/components/StudyPane/Toolbar/index.tsx
+++ b/src/components/StudyPane/Toolbar/index.tsx
@@ -25,7 +25,7 @@ const Toolbar = ({
   /* TODO: may need to refactor this part after more features are added to view mode*/
   return (
     <div className="fixed top-19 left-0 mr-auto ml-auto z-20 flex justify-center w-full max-w-full hbFontExemption">
-      <div id="selaToolbar" className="fixed left-0 mx-auto pl-11 pr-11 max-w-220 bg-white py-2 w-full">
+      <div className="fixed left-0 mx-auto pl-11 pr-11 max-w-220 bg-white py-2 w-full">
 
       { // only show zoom in/out & uniform width buttons in view only mode
         ctxInViewMode

--- a/src/components/StudyPane/Toolbar/index.tsx
+++ b/src/components/StudyPane/Toolbar/index.tsx
@@ -20,16 +20,16 @@ const Toolbar = ({
   setUniformWidth: (arg: boolean) => void;
 } ) => {
   
-  const { ctxScaleValue, ctxInViewMode } = useContext(FormatContext);
+  const { ctxInViewMode } = useContext(FormatContext);
   
   /* TODO: may need to refactor this part after more features are added to view mode*/
   return (
     <div className="fixed top-19 left-0 mr-auto ml-auto z-20 flex justify-center w-full max-w-full">
-      <div className="fixed left-0 mx-auto pl-11 pr-11 max-w-220 bg-white py-2 w-full">
+      <div id="selaToolbar" className="fixed left-0 mx-auto pl-11 pr-11 max-w-220 bg-white py-2 w-full">
       { // only show zoom in/out & uniform width buttons in view only mode
         ctxInViewMode
         ? (<div className="flex">
-            <ScaleDropDown />
+            <ScaleDropDown setScaleValue={setScaleValue} />
             <UniformWidthBtn setUniformWidth={setUniformWidth}/>
         </div>)
         : (<div className="flex">
@@ -37,7 +37,7 @@ const Toolbar = ({
             <UndoBtn />
             <RedoBtn />
           </div>*/}
-
+          <ScaleDropDown setScaleValue={setScaleValue} />
           <ColorActionBtn colorAction={ColorActionType.colorFill} setColorAction={setColorAction} setSelectedColor={setSelectedColor}/>
           <ColorActionBtn colorAction={ColorActionType.borderColor} setColorAction={setColorAction} setSelectedColor={setSelectedColor}/>
           <ColorActionBtn colorAction={ColorActionType.textColor} setColorAction={setColorAction} setSelectedColor={setSelectedColor}/>

--- a/src/components/StudyPane/Toolbar/index.tsx
+++ b/src/components/StudyPane/Toolbar/index.tsx
@@ -1,11 +1,6 @@
-<<<<<<< HEAD
-import { UndoBtn, RedoBtn, ZoomInBtn, ZoomOutBtn, ColorActionBtn, ClearFormatBtn, MoveUpBtn, MoveDownBtn, 
-  IndentBtn, UniformWidthBtn, StropheActionBtn, NewStanzaBtn } from "./Buttons";
-import ScaleDropDown from "./ScaleDropDown";
-=======
 import { UndoBtn, RedoBtn, ZoomInBtn, ZoomOutBtn, ColorActionBtn, ClearFormatBtn, 
   IndentBtn, UniformWidthBtn, StructureUpdateBtn, NewStanzaBtn } from "./Buttons";
->>>>>>> main
+import ScaleDropDown from "./ScaleDropDown";
 import { useContext } from "react";
 import { FormatContext } from '../index';
 import { ColorActionType, StructureUpdateType } from "@/lib/types";

--- a/src/components/StudyPane/Toolbar/index.tsx
+++ b/src/components/StudyPane/Toolbar/index.tsx
@@ -1,25 +1,26 @@
 import { UndoBtn, RedoBtn, ZoomInBtn, ZoomOutBtn, ColorActionBtn, ClearFormatBtn, MoveUpBtn, MoveDownBtn, 
   IndentBtn, UniformWidthBtn, StropheActionBtn, NewStanzaBtn } from "./Buttons";
+import ScaleDropDown from "./ScaleDropDown";
 import { useContext } from "react";
 import { FormatContext } from '../index';
 import { ColorActionType, StropheActionType } from "@/lib/types";
 
 const Toolbar = ({
-  setZoomLevel,
+  setScaleValue,
   //color functions
   setColorAction,
   setSelectedColor,
 
   setUniformWidth
 }: {
-  setZoomLevel: (arg: number) => void;
+  setScaleValue: (arg: number) => void;
   //color functions
   setColorAction: (arg: number) => void,
   setSelectedColor: (arg: string) => void;
   setUniformWidth: (arg: boolean) => void;
 } ) => {
   
-  const { ctxZoomLevel, ctxInViewMode } = useContext(FormatContext);
+  const { ctxScaleValue, ctxInViewMode } = useContext(FormatContext);
   
   /* TODO: may need to refactor this part after more features are added to view mode*/
   return (
@@ -28,13 +29,7 @@ const Toolbar = ({
       { // only show zoom in/out & uniform width buttons in view only mode
         ctxInViewMode
         ? (<div className="flex">
-            <ZoomOutBtn zoomLevel={ctxZoomLevel} setZoomLevel={setZoomLevel} />
-            <div className="flex flex-col group relative inline-block items-center justify-center xsm:flex-row">
-              <span className="rounded-md border-[.5px] text-center ml-3 border-stroke bg-gray-2 px-4 py-0.5 text-base font-medium text-black dark:border-strokedark dark:bg-boxdark-2 dark:text-white">
-              {ctxZoomLevel}
-              </span>
-            </div>
-            <ZoomInBtn zoomLevel={ctxZoomLevel} setZoomLevel={setZoomLevel} />
+            <ScaleDropDown />
             <UniformWidthBtn setUniformWidth={setUniformWidth}/>
         </div>)
         : (<div className="flex">
@@ -42,14 +37,6 @@ const Toolbar = ({
             <UndoBtn />
             <RedoBtn />
           </div>*/}
-
-          <ZoomOutBtn zoomLevel={ctxZoomLevel} setZoomLevel={setZoomLevel} />
-          <div className="flex flex-col group relative inline-block items-center justify-center xsm:flex-row">
-            <span className="rounded-md border-[.5px] text-center ml-2 border-stroke bg-gray-2 px-4 py-0.5 text-base font-medium text-black dark:border-strokedark dark:bg-boxdark-2 dark:text-white">
-            {ctxZoomLevel}
-            </span>
-          </div>
-          <ZoomInBtn zoomLevel={ctxZoomLevel} setZoomLevel={setZoomLevel} />
 
           <ColorActionBtn colorAction={ColorActionType.colorFill} setColorAction={setColorAction} setSelectedColor={setSelectedColor}/>
           <ColorActionBtn colorAction={ColorActionType.borderColor} setColorAction={setColorAction} setSelectedColor={setSelectedColor}/>

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -9,14 +9,14 @@ import InfoPane from "./InfoPane";
 import { ColorActionType, InfoPaneActionType, StropheActionType } from "@/lib/types";
 import { StudyData, PassageData, HebWord, StropheData } from '@/lib/data';
 
-export const DEFAULT_ZOOM_LEVEL: number = 5;
+export const DEFAULT_SCALE_VALUE: number = 1;
 export const DEFAULT_COLOR_FILL = "#FFFFFF";
 export const DEFAULT_BORDER_COLOR = "#D9D9D9";
 export const DEFAULT_TEXT_COLOR = "#656565";
 
 export const FormatContext = createContext({
   ctxStudyId: "",
-  ctxZoomLevel: DEFAULT_ZOOM_LEVEL,
+  ctxScaleValue: DEFAULT_SCALE_VALUE,
   ctxIsHebrew: false,
   ctxSelectedHebWords: [] as HebWord[],
   ctxSetSelectedHebWords: (arg: HebWord[]) => {},
@@ -52,7 +52,7 @@ const StudyPane = ({
   content: PassageData;
   inViewMode: boolean;
 }) => {
-  const [zoomLevel, setZoomLevel] = useState(DEFAULT_ZOOM_LEVEL);
+  const [scaleValue, setScaleValue] = useState(DEFAULT_SCALE_VALUE);
   const [isHebrew, setHebrew] = useState(false);
 
   const [selectedWords, setSelectedWords] = useState<number[]>([]);
@@ -75,7 +75,7 @@ const StudyPane = ({
 
   const formatContextValue = {
     ctxStudyId: study.id,
-    ctxZoomLevel: zoomLevel,
+    ctxScaleValue: scaleValue,
     ctxIsHebrew: isHebrew,
     ctxSelectedHebWords: selectedHebWords,
     ctxSetSelectedHebWords: setSelectedHebWords,    
@@ -123,7 +123,7 @@ const StudyPane = ({
           <div {...passageDivStyle}>
 
             <Toolbar
-              setZoomLevel={setZoomLevel}
+              setScaleValue={setScaleValue}
               //color functions
               setColorAction={setColorAction}
               setSelectedColor={setSelectedColor}


### PR DESCRIPTION
In this PR:
- remove zoom in/out buttons from the toolbar
- add scale dropdown to control passage scale
- fix the drag rectangle
- add scale buttons (add/minus scale by 5%)
- update the scale range to [25%, 200%]
- override passage width on a large scale to avoid strophe buttons out of viewport

TBD:
- may need to update the override method