### PR TITLE
Pull Request 2024-10-23 Fix stanza horizontal placement & collapse bug

### DIFF
--- a/src/components/StudyPane/InfoPane/index.tsx
+++ b/src/components/StudyPane/InfoPane/index.tsx
@@ -23,7 +23,7 @@ const InfoPane = ({
 
     return (
         <aside
-            className={`h-full top-19 flex-col overflow-y-auto bg-white transition-all duration-300 ${
+            className={`fixed h-full top-19 flex-col overflow-y-auto bg-white transition-all duration-300 ${
                 infoPaneAction !== InfoPaneActionType.none ? "w-1/4" : "w-0"
             } fixed right-0 top-0 z-30 border-l-2`}
             style={{ borderColor: "rgb(203 213 225)" }}

--- a/src/components/StudyPane/InfoPane/index.tsx
+++ b/src/components/StudyPane/InfoPane/index.tsx
@@ -20,7 +20,6 @@ const InfoPane = ({
         setInfoPaneAction(InfoPaneActionType.none)
     }
 
-
     return (
         <aside
             className={`fixed h-full top-19 flex-col overflow-y-auto bg-white transition-all duration-300 ${

--- a/src/components/StudyPane/Passage/StanzaBlock.tsx
+++ b/src/components/StudyPane/Passage/StanzaBlock.tsx
@@ -28,7 +28,7 @@ export const  StanzaBlock = ({
     return(
         <div
         key={"stanza_" + stanza.id}
-        className={`relative flex-column pt-10 flex-1 mr-1 px-1 py-2 my-1 rounded border`} 
+        className={`relative flex-column pt-10 ${expanded ? 'flex-1' : ''} mr-1 px-1 py-2 my-1 rounded border`} 
         >
         <div
           className={`z-1 absolute top-0 p-[0.5] m-[0.5] bg-transparent ${ctxIsHebrew ? 'left-0' : 'right-0'}`}

--- a/src/components/StudyPane/Passage/StanzaBlock.tsx
+++ b/src/components/StudyPane/Passage/StanzaBlock.tsx
@@ -21,7 +21,6 @@ export const  StanzaBlock = ({
         // remove any selected word blocks if strophe block is collapsed
         ctxSetSelectedHebWords([]);
         ctxSetNumSelectedWords(0);
-        
       }
     }
 

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -117,8 +117,12 @@ const StudyPane = ({
 
 
   const passageDivStyle = {
-    className: `flex overflow-y-auto h-full ${infoPaneAction !== InfoPaneActionType.none ? 'w-3/4' : 'w-full'} ${isHebrew ? "hbFont" : ""}`
+    // className: `flex overflow-y-auto h-full ${infoPaneAction !== InfoPaneActionType.none ? 'w-3/4' : 'w-full'} ${isHebrew ? "hbFont" : ""}`
+    className: `flex overflow-y-auto h-full w-full ${isHebrew ? "hbFont" : ""}`
   };
+  const studyPaneWrapperStyle = {
+    className: `grid gap-x-2 ${infoPaneAction !== InfoPaneActionType.none ? 'grid-cols-[3fr_1fr]' : ''} relative h-full`
+  }
   
   return (
     <>
@@ -130,7 +134,8 @@ const StudyPane = ({
           infoPaneAction={infoPaneAction}
         />
   
-        <main className="flex flex-row relative h-full">
+        {/* <main className="flex flex-row relative h-full"> */}
+        <main {...studyPaneWrapperStyle}>
           <div {...passageDivStyle}>
             <Toolbar
               setScaleValue={setScaleValue}
@@ -145,7 +150,7 @@ const StudyPane = ({
   
           {
             infoPaneAction !== InfoPaneActionType.none && (
-              <div className="fixed top-19 right-0 w-1/4 h-full z-30 bg-white border-l border-gray-300">
+              <div className="relative top-19 right-0 w-1/4 h-full z-30 bg-white border-l border-gray-300">
                 <InfoPane
                   infoPaneAction={infoPaneAction}
                   setInfoPaneAction={setInfoPaneAction}

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -117,7 +117,6 @@ const StudyPane = ({
 
 
   const passageDivStyle = {
-    // className: `flex overflow-y-auto h-full ${infoPaneAction !== InfoPaneActionType.none ? 'w-3/4' : 'w-full'} ${isHebrew ? "hbFont" : ""}`
     className: `flex overflow-y-auto h-full w-full ${isHebrew ? "hbFont" : ""}`
   };
   const studyPaneWrapperStyle = {
@@ -134,7 +133,6 @@ const StudyPane = ({
           infoPaneAction={infoPaneAction}
         />
   
-        {/* <main className="flex flex-row relative h-full"> */}
         <main {...studyPaneWrapperStyle}>
           <div {...passageDivStyle}>
             <Toolbar


### PR DESCRIPTION
Fix bug: parts of stanza are cut off when motif is on, horizontal scroll bar exceeds the boundary of stanza when motif is on, stanza wont fully collapse when collapsed.

first two bugs fixed by changing <main> to display: grid and apply grid-template-column: 3fr 1fr
