### PR TITLE
add motif and lexicon root in db

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -558,9 +558,10 @@ export async function fetchPassageContent(studyId: string) {
           .filter("chapter", le(passageInfo.endChapter))
           .filter("verse", ge(passageInfo.startVerse))
           .filter("verse", le(passageInfo.endVerse))
+          .select(["*", "motifLink.categories", "motifLink.rootLink.*"])
           .sort("hebId", "asc")
           .getAll();
-
+        
         let currentStanzaIdx = -1;
         let currentStropheIdx = -1;
         let runningStropheIdx = -1;
@@ -583,6 +584,14 @@ export async function fetchPassageContent(studyId: string) {
           hebWord.firstWordInStrophe = false;
           hebWord.firstStropheInStanza = false; 
           hebWord.lastStropheInStanza = false;
+          if (word.motifLink?.rootLink) {
+            hebWord.rootData = {
+              strongCode: word.motifLink.rootLink.id,
+              lemma: word.motifLink.rootLink.lemma || "",
+              gloss: word.motifLink.rootLink.gloss || "",
+            };
+          }
+          hebWord.categories = word.motifLink?.categories || [];
 
           const currentWordStyling = wordStylingMap.get(hebWord.id);
           if (currentWordStyling !== undefined) {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -31,6 +31,14 @@ export type HebWord = {
     lastStropheInStanza: boolean;
     stanzaId: number | undefined;
     stanzaDiv?: boolean;
+    rootData: LexiconData | undefined;
+    categories: string[];
+}
+
+export type LexiconData = {
+    strongCode: string;
+    lemma: string;
+    gloss: string;
 }
 
 export type LineData = {

--- a/src/xata.ts
+++ b/src/xata.ts
@@ -101,17 +101,6 @@ const tables = [
       { name: "ETCBCgloss", type: "string" },
     ],
   },
-  { name: "domain", columns: [{ name: "name", type: "string" }] },
-  {
-    name: "step_lexicon_root",
-    columns: [
-      { name: "strongCode", type: "int" },
-      { name: "rootCode", type: "int" },
-      { name: "gloss", type: "string" },
-      { name: "lemma", type: "string" },
-      { name: "domains", type: "multiple" },
-    ],
-  },
   {
     name: "heb_bible",
     columns: [
@@ -140,17 +129,25 @@ const tables = [
       { name: "BSBVersion", type: "string" },
       { name: "mergecolumn", type: "float" },
       { name: "BSBnewLine", type: "bool" },
+      { name: "motifLink", type: "link", link: { table: "motif" } },
     ],
   },
   {
     name: "motif",
     columns: [
       { name: "strongCode", type: "int" },
+      { name: "categories", type: "multiple" },
+      { name: "rootLink", type: "link", link: { table: "lexicon" } },
+    ],
+    revLinks: [{ column: "motifLink", table: "heb_bible" }],
+  },
+  {
+    name: "lexicon",
+    columns: [
       { name: "gloss", type: "text" },
       { name: "lemma", type: "text" },
-      { name: "rootCode", type: "int" },
-      { name: "categories", type: "multiple" },
     ],
+    revLinks: [{ column: "rootLink", table: "motif" }],
   },
 ] as const;
 
@@ -175,17 +172,14 @@ export type StanzaStylingRecord = StanzaStyling & XataRecord;
 export type HebBibleOld = InferredTypes["heb_bible_old"];
 export type HebBibleOldRecord = HebBibleOld & XataRecord;
 
-export type Domain = InferredTypes["domain"];
-export type DomainRecord = Domain & XataRecord;
-
-export type StepLexiconRoot = InferredTypes["step_lexicon_root"];
-export type StepLexiconRootRecord = StepLexiconRoot & XataRecord;
-
 export type HebBible = InferredTypes["heb_bible"];
 export type HebBibleRecord = HebBible & XataRecord;
 
 export type Motif = InferredTypes["motif"];
 export type MotifRecord = Motif & XataRecord;
+
+export type Lexicon = InferredTypes["lexicon"];
+export type LexiconRecord = Lexicon & XataRecord;
 
 export type DatabaseSchema = {
   study: StudyRecord;
@@ -194,10 +188,9 @@ export type DatabaseSchema = {
   stropheStyling: StropheStylingRecord;
   stanzaStyling: StanzaStylingRecord;
   heb_bible_old: HebBibleOldRecord;
-  domain: DomainRecord;
-  step_lexicon_root: StepLexiconRootRecord;
   heb_bible: HebBibleRecord;
   motif: MotifRecord;
+  lexicon: LexiconRecord;
 };
 
 const DatabaseClient = buildClient();


### PR DESCRIPTION
- Synchronize db schema and queries with the latest db
  - add lexicon table to store the root words
  - add motif table to store the categories (synonym) and root
  - add link to motif in heb_bible

TODO in the next PR:
- Display root gloss in the identical root tab