### PR TITLE
feat: add related word tab in motif

### DIFF
--- a/src/components/StudyPane/InfoPane/Motif/RelatedWord.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/RelatedWord.tsx
@@ -1,0 +1,107 @@
+import React, { useContext } from 'react';
+
+import { PassageData, HebWord, LexiconData } from "@/lib/data";
+import { ColorActionType, ColorType } from "@/lib/types";
+import { updateWordColor } from "@/lib/actions";
+
+import { RelatedWordBlock } from "./RelatedWordBlock";
+import { DEFAULT_COLOR_FILL, DEFAULT_TEXT_COLOR, FormatContext } from '../../index';
+
+const RelWordColorPalette = [
+    '#e57373', '#64b5f6', '#81c784', '#ffeb3b', '#ffb74d', '#90a4ae', '#9575cd', '#00bcd4', '#f06292', '#a1887f',
+    '#ffccbc', '#bbdefb', '#c8e6c9', '#fff9c4', '#ffe0b2', '#cfd8dc', '#d1c4e9', '#b2ebf2', '#f8bbd0', '#d7ccc8',
+    '#b71c1c', '#1976d2', '#388e3c', '#afb42b', '#ff6f00', '#607d8b', '#673ab7', '#0097a7', '#e91e63', '#795548'
+];
+
+const RelatedWord = ({
+    content
+}: {
+    content: PassageData;
+}) => {
+
+    const { ctxStudyId, ctxSetRelWordsColorMap } = useContext(FormatContext);
+
+    /** 
+     * RootData is extracted from the related_words section in the StepBible heb word dictionary
+     * if word H0001, H0007, H0008, ... are related, then H0001 is the "root" word of all the words in the relation group
+     * notice that the root word is not necessarily the real root word of other words in hebrew 
+    **/
+    let rootWordMap = new Map<string, HebWord[]>();
+    content.stanzas.forEach((stanzas) => {
+        stanzas.strophes.forEach((strophe) => {
+            strophe.lines.forEach((line) => {
+                line.words.forEach((word) => {
+                    if (word.rootData?.strongCode) {
+                        const currentWord = rootWordMap.get(word.rootData.strongCode);
+                        if (currentWord !== undefined) {
+                            currentWord.push(word);
+                        } else {
+                            rootWordMap.set(word.rootData.strongCode, [word]);
+                        }
+                    }
+                });
+            });
+        });
+    });
+
+    type RelatedWordGroupProp = {
+        rootData: LexiconData,
+        count: number,
+        words: HebWord[]
+    };
+    let relWordGroups: RelatedWordGroupProp[] = [];
+    rootWordMap.forEach((groupedWords) => {
+        // exclude identical words
+        const distinctWords = new Set(groupedWords.map(word => word.strongNumber));
+        if (distinctWords.size > 1 && groupedWords[0].rootData) {
+            relWordGroups.push({ rootData: groupedWords[0].rootData, count: groupedWords.length, words: groupedWords });
+        }
+    });
+    relWordGroups.sort((a, b) => b.count - a.count);
+
+    const handleSmartHighlightClick = () => {
+
+        let newMap = new Map<string, ColorType>();
+
+        relWordGroups.forEach((group, index) => {
+            let wordIds: number[] = [];
+            group.words.forEach((word) => {
+                wordIds.push(word.id)
+            });
+
+            let relWordBlockColor: ColorType = {
+                colorFill: (index < RelWordColorPalette.length) ? RelWordColorPalette[index] : DEFAULT_COLOR_FILL,
+                textColor: (index < 10) ? '#000000' : (index < 20 || index >= RelWordColorPalette.length) ? DEFAULT_TEXT_COLOR : '#FFFFFF',
+                borderColor: "" // not used for root block
+            };
+
+            updateWordColor(ctxStudyId, wordIds, ColorActionType.colorFill, relWordBlockColor.colorFill);
+            updateWordColor(ctxStudyId, wordIds, ColorActionType.textColor, relWordBlockColor.textColor);
+            newMap.set(group.rootData.strongCode, relWordBlockColor);
+        })
+        ctxSetRelWordsColorMap(newMap);
+    }
+
+    return (
+        <div className="flex-col h-full">
+            <div
+                style={{ height: '70%' }}
+                className=" gap-4 pb-8 overflow-y-auto">
+                <div className ="flex flex-wrap">
+                    { relWordGroups.map((group, index) => (
+                        <RelatedWordBlock key={index} id={index} count={group.count} rootData={group.rootData} relatedWords={group.words} />
+                    )) }
+                </div>
+            </div>
+            <div className="w-full bottom-0 left-0 flex justify-center mt-3">
+                <button
+                    className="inline-flex items-center justify-center gap-2.5 rounded-full bg-primary px-8 py-4 text-center font-medium text-white hover:bg-opacity-90 lg:px-8 xl:px-10"
+                    onClick={() => handleSmartHighlightClick()}
+                >
+                    Smart Highlight
+                </button>
+            </div>
+        </div>
+    );
+};
+export default RelatedWord;

--- a/src/components/StudyPane/InfoPane/Motif/RelatedWord.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/RelatedWord.tsx
@@ -1,30 +1,18 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 import { PassageData, HebWord, LexiconData } from "@/lib/data";
-import { ColorActionType, ColorType } from "@/lib/types";
-import { updateWordColor } from "@/lib/actions";
-
 import { RelatedWordBlock } from "./RelatedWordBlock";
-import { DEFAULT_COLOR_FILL, DEFAULT_TEXT_COLOR, FormatContext } from '../../index';
-
-const RelWordColorPalette = [
-    '#e57373', '#64b5f6', '#81c784', '#ffeb3b', '#ffb74d', '#90a4ae', '#9575cd', '#00bcd4', '#f06292', '#a1887f',
-    '#ffccbc', '#bbdefb', '#c8e6c9', '#fff9c4', '#ffe0b2', '#cfd8dc', '#d1c4e9', '#b2ebf2', '#f8bbd0', '#d7ccc8',
-    '#b71c1c', '#1976d2', '#388e3c', '#afb42b', '#ff6f00', '#607d8b', '#673ab7', '#0097a7', '#e91e63', '#795548'
-];
 
 const RelatedWord = ({
     content
 }: {
     content: PassageData;
 }) => {
-
-    const { ctxStudyId, ctxSetRelWordsColorMap } = useContext(FormatContext);
-
     /** 
      * RootData is extracted from the related_words section in the StepBible heb word dictionary
-     * if word H0001, H0007, H0008, ... are related, then H0001 is the "root" word of all the words in the relation group
-     * notice that the root word is not necessarily the real root word of other words in hebrew 
+     * if word H0001, H0007, H0008, ... are related, 
+     * then H0001, the word with the smallest strongNumber is the "root" word of all the related words
+     * the root word is not necessarily the real root word of others in hebrew 
     **/
     let rootWordMap = new Map<string, HebWord[]>();
     content.stanzas.forEach((stanzas) => {
@@ -59,29 +47,6 @@ const RelatedWord = ({
     });
     relWordGroups.sort((a, b) => b.count - a.count);
 
-    const handleSmartHighlightClick = () => {
-
-        let newMap = new Map<string, ColorType>();
-
-        relWordGroups.forEach((group, index) => {
-            let wordIds: number[] = [];
-            group.words.forEach((word) => {
-                wordIds.push(word.id)
-            });
-
-            let relWordBlockColor: ColorType = {
-                colorFill: (index < RelWordColorPalette.length) ? RelWordColorPalette[index] : DEFAULT_COLOR_FILL,
-                textColor: (index < 10) ? '#000000' : (index < 20 || index >= RelWordColorPalette.length) ? DEFAULT_TEXT_COLOR : '#FFFFFF',
-                borderColor: "" // not used for root block
-            };
-
-            updateWordColor(ctxStudyId, wordIds, ColorActionType.colorFill, relWordBlockColor.colorFill);
-            updateWordColor(ctxStudyId, wordIds, ColorActionType.textColor, relWordBlockColor.textColor);
-            newMap.set(group.rootData.strongCode, relWordBlockColor);
-        })
-        ctxSetRelWordsColorMap(newMap);
-    }
-
     return (
         <div className="flex-col h-full">
             <div
@@ -92,14 +57,6 @@ const RelatedWord = ({
                         <RelatedWordBlock key={index} id={index} count={group.count} rootData={group.rootData} relatedWords={group.words} />
                     )) }
                 </div>
-            </div>
-            <div className="w-full bottom-0 left-0 flex justify-center mt-3">
-                <button
-                    className="inline-flex items-center justify-center gap-2.5 rounded-full bg-primary px-8 py-4 text-center font-medium text-white hover:bg-opacity-90 lg:px-8 xl:px-10"
-                    onClick={() => handleSmartHighlightClick()}
-                >
-                    Smart Highlight
-                </button>
             </div>
         </div>
     );

--- a/src/components/StudyPane/InfoPane/Motif/RelatedWordBlock.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/RelatedWordBlock.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useEffect, useContext } from 'react';
+
+import { DEFAULT_COLOR_FILL, DEFAULT_BORDER_COLOR, DEFAULT_TEXT_COLOR, FormatContext } from '../../index';
+import { ColorActionType } from "@/lib/types";
+import { HebWord, LexiconData } from '@/lib/data';
+
+export const RelatedWordBlock = ({
+  id, count, rootData, relatedWords
+}: {
+  id: number,
+  count: number,
+  rootData: LexiconData,
+  relatedWords: HebWord[]
+}) => {
+
+  const { ctxRelWordsColorMap, ctxColorAction, ctxSelectedColor, ctxSelectedHebWords, ctxSetNumSelectedWords, ctxSetSelectedHebWords } = useContext(FormatContext)
+  
+  let defaultColorFill = relatedWords[0].colorFill || DEFAULT_COLOR_FILL;
+  let defaultBorderColor = relatedWords[0].borderColor || DEFAULT_BORDER_COLOR;
+  let defaultTextColor = relatedWords[0].textColor || DEFAULT_TEXT_COLOR;
+
+  const relBlockColor = ctxRelWordsColorMap.get(rootData.strongCode);
+  if (relBlockColor) {
+    defaultColorFill = relBlockColor.colorFill;
+    defaultTextColor = relBlockColor.textColor;
+  }
+
+  relatedWords.forEach((dsd) => {
+    if (dsd.colorFill !== defaultColorFill) { defaultColorFill = DEFAULT_COLOR_FILL; }
+    if (dsd.borderColor !== defaultBorderColor) { defaultBorderColor = DEFAULT_BORDER_COLOR; }
+    if (dsd.textColor !== defaultTextColor) { defaultTextColor = DEFAULT_TEXT_COLOR; }
+  });
+
+  const [colorFillLocal, setColorFillLocal] = useState(defaultColorFill);
+  const [borderColorLocal, setBorderColorLocal] = useState(defaultBorderColor);
+  const [textColorLocal, setTextColorLocal] = useState(defaultTextColor);
+  const [selected, setSelected] = useState(false);
+
+  useEffect(() => {
+    const relBlockColor = ctxRelWordsColorMap.get(rootData.strongCode);
+    if (relBlockColor) {
+      setColorFillLocal(relBlockColor.colorFill);
+      setTextColorLocal(relBlockColor.textColor);
+    }
+  }, [ctxRelWordsColorMap]);
+  
+  useEffect(() => {
+    const colorFill = relatedWords[0].colorFill;
+    const isSameColorFill = relatedWords.every((x) => x.colorFill === colorFill);
+    if (!isSameColorFill) {
+       setColorFillLocal(DEFAULT_COLOR_FILL);
+    } else if (colorFill != colorFillLocal) { setColorFillLocal(colorFill); }
+
+    const textColor = relatedWords[0].textColor;
+    const isSameTextColor = relatedWords.every((x) => x.textColor === textColor);
+    if (!isSameTextColor) {
+       setTextColorLocal(DEFAULT_TEXT_COLOR);
+    } else if (textColor != textColorLocal) { setTextColorLocal(textColor); }
+  }, [relatedWords]);
+
+  useEffect(() => {
+    let hasChildren = true;
+    relatedWords.forEach((dsd) => {
+      hasChildren = hasChildren && ctxSelectedHebWords.includes(dsd);
+    })
+
+    setSelected(hasChildren);
+  }, [ctxSelectedHebWords, relatedWords]);
+
+  const handleClick = (e: React.MouseEvent) => {
+    setSelected(prevState => !prevState);
+
+    let updatedSelectedHebWords = [...ctxSelectedHebWords];
+    if (!selected) {
+      updatedSelectedHebWords = ctxSelectedHebWords.concat(relatedWords);
+    } else {
+      relatedWords.forEach((dsd) => {
+        updatedSelectedHebWords.splice(updatedSelectedHebWords.indexOf(dsd), 1)
+      })
+    }
+    ctxSetSelectedHebWords(updatedSelectedHebWords);
+    ctxSetNumSelectedWords(updatedSelectedHebWords.length);
+  };
+
+  useEffect(() => {
+    if (ctxColorAction !== ColorActionType.none && selected) {
+      if (ctxColorAction === ColorActionType.colorFill && ctxSelectedColor) {
+        setColorFillLocal(ctxSelectedColor);
+      } else if (ctxColorAction === ColorActionType.borderColor && ctxSelectedColor) {
+        setBorderColorLocal(ctxSelectedColor);
+      } else if (ctxColorAction === ColorActionType.textColor && ctxSelectedColor) {
+        setTextColorLocal(ctxSelectedColor);
+      } else if (ctxColorAction === ColorActionType.resetColor) {
+        setColorFillLocal(DEFAULT_COLOR_FILL);
+        setBorderColorLocal(DEFAULT_BORDER_COLOR);
+        setTextColorLocal(DEFAULT_TEXT_COLOR);
+      }
+    }
+  }, [ctxColorAction, ctxSelectedColor, selected]);
+
+  return (
+    <div className="flex my-1">
+      <div
+        id={id.toString()}
+        key={id}
+        className={`wordBlock mx-1 ClickBlock ${selected ? 'rounded border outline outline-offset-1 outline-[3px] outline-[#FFC300] drop-shadow-md' : 'rounded border outline-offset-[-4px]'}`}
+        data-clicktype="clickable"
+        style={
+          {
+            background: `${colorFillLocal}`,
+            border: `2px solid ${borderColorLocal}`,
+            color: `${textColorLocal}`,
+          }
+        }>
+        <span
+          className="flex mx-1 my-1"
+          onClick={handleClick}
+        >
+          <span
+            className={`flex select-none px-2 py-1 items-center justify-center text-center hover:opacity-60 leading-none text-lg`}
+          >{rootData.gloss}</span>
+          <span className="flex h-6.5 w-full min-w-6.5 max-w-6.5 items-center justify-center rounded-full bg-[#EFEFEF] text-black text-sm">{count}</span>
+        </span>
+      </div>
+    </div>
+  );
+
+}

--- a/src/components/StudyPane/InfoPane/Motif/RelatedWordBlock.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/RelatedWordBlock.tsx
@@ -12,7 +12,7 @@ export const RelatedWordBlock = ({
   relatedWords: HebWord[]
 }) => {
 
-  const { ctxSelectedHebWords, ctxSetNumSelectedWords, ctxSetSelectedHebWords } = useContext(FormatContext)
+  const { ctxIsHebrew, ctxSelectedHebWords, ctxSetNumSelectedWords, ctxSetSelectedHebWords } = useContext(FormatContext)
   const [selected, setSelected] = useState(false);
 
   const handleClick = (e: React.MouseEvent) => {
@@ -50,7 +50,7 @@ export const RelatedWordBlock = ({
         >
           <span
             className={`flex select-none px-2 py-1 items-center justify-center text-center hover:opacity-60 leading-none text-lg`}
-          >{rootData.gloss}</span>
+          > { ctxIsHebrew ? rootData.lemma : rootData.gloss } </span>
           <span className="flex h-6.5 w-full min-w-6.5 max-w-6.5 items-center justify-center rounded-full bg-[#EFEFEF] text-black text-sm">{count}</span>
         </span>
       </div>

--- a/src/components/StudyPane/InfoPane/Motif/RelatedWordBlock.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/RelatedWordBlock.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 
 import { DEFAULT_COLOR_FILL, DEFAULT_BORDER_COLOR, DEFAULT_TEXT_COLOR, FormatContext } from '../../index';
-import { ColorActionType } from "@/lib/types";
 import { HebWord, LexiconData } from '@/lib/data';
 
 export const RelatedWordBlock = ({
@@ -13,59 +12,8 @@ export const RelatedWordBlock = ({
   relatedWords: HebWord[]
 }) => {
 
-  const { ctxRelWordsColorMap, ctxColorAction, ctxSelectedColor, ctxSelectedHebWords, ctxSetNumSelectedWords, ctxSetSelectedHebWords } = useContext(FormatContext)
-  
-  let defaultColorFill = relatedWords[0].colorFill || DEFAULT_COLOR_FILL;
-  let defaultBorderColor = relatedWords[0].borderColor || DEFAULT_BORDER_COLOR;
-  let defaultTextColor = relatedWords[0].textColor || DEFAULT_TEXT_COLOR;
-
-  const relBlockColor = ctxRelWordsColorMap.get(rootData.strongCode);
-  if (relBlockColor) {
-    defaultColorFill = relBlockColor.colorFill;
-    defaultTextColor = relBlockColor.textColor;
-  }
-
-  relatedWords.forEach((dsd) => {
-    if (dsd.colorFill !== defaultColorFill) { defaultColorFill = DEFAULT_COLOR_FILL; }
-    if (dsd.borderColor !== defaultBorderColor) { defaultBorderColor = DEFAULT_BORDER_COLOR; }
-    if (dsd.textColor !== defaultTextColor) { defaultTextColor = DEFAULT_TEXT_COLOR; }
-  });
-
-  const [colorFillLocal, setColorFillLocal] = useState(defaultColorFill);
-  const [borderColorLocal, setBorderColorLocal] = useState(defaultBorderColor);
-  const [textColorLocal, setTextColorLocal] = useState(defaultTextColor);
+  const { ctxSelectedHebWords, ctxSetNumSelectedWords, ctxSetSelectedHebWords } = useContext(FormatContext)
   const [selected, setSelected] = useState(false);
-
-  useEffect(() => {
-    const relBlockColor = ctxRelWordsColorMap.get(rootData.strongCode);
-    if (relBlockColor) {
-      setColorFillLocal(relBlockColor.colorFill);
-      setTextColorLocal(relBlockColor.textColor);
-    }
-  }, [ctxRelWordsColorMap]);
-  
-  useEffect(() => {
-    const colorFill = relatedWords[0].colorFill;
-    const isSameColorFill = relatedWords.every((x) => x.colorFill === colorFill);
-    if (!isSameColorFill) {
-       setColorFillLocal(DEFAULT_COLOR_FILL);
-    } else if (colorFill != colorFillLocal) { setColorFillLocal(colorFill); }
-
-    const textColor = relatedWords[0].textColor;
-    const isSameTextColor = relatedWords.every((x) => x.textColor === textColor);
-    if (!isSameTextColor) {
-       setTextColorLocal(DEFAULT_TEXT_COLOR);
-    } else if (textColor != textColorLocal) { setTextColorLocal(textColor); }
-  }, [relatedWords]);
-
-  useEffect(() => {
-    let hasChildren = true;
-    relatedWords.forEach((dsd) => {
-      hasChildren = hasChildren && ctxSelectedHebWords.includes(dsd);
-    })
-
-    setSelected(hasChildren);
-  }, [ctxSelectedHebWords, relatedWords]);
 
   const handleClick = (e: React.MouseEvent) => {
     setSelected(prevState => !prevState);
@@ -82,22 +30,6 @@ export const RelatedWordBlock = ({
     ctxSetNumSelectedWords(updatedSelectedHebWords.length);
   };
 
-  useEffect(() => {
-    if (ctxColorAction !== ColorActionType.none && selected) {
-      if (ctxColorAction === ColorActionType.colorFill && ctxSelectedColor) {
-        setColorFillLocal(ctxSelectedColor);
-      } else if (ctxColorAction === ColorActionType.borderColor && ctxSelectedColor) {
-        setBorderColorLocal(ctxSelectedColor);
-      } else if (ctxColorAction === ColorActionType.textColor && ctxSelectedColor) {
-        setTextColorLocal(ctxSelectedColor);
-      } else if (ctxColorAction === ColorActionType.resetColor) {
-        setColorFillLocal(DEFAULT_COLOR_FILL);
-        setBorderColorLocal(DEFAULT_BORDER_COLOR);
-        setTextColorLocal(DEFAULT_TEXT_COLOR);
-      }
-    }
-  }, [ctxColorAction, ctxSelectedColor, selected]);
-
   return (
     <div className="flex my-1">
       <div
@@ -107,9 +39,9 @@ export const RelatedWordBlock = ({
         data-clicktype="clickable"
         style={
           {
-            background: `${colorFillLocal}`,
-            border: `2px solid ${borderColorLocal}`,
-            color: `${textColorLocal}`,
+            background: `${DEFAULT_COLOR_FILL}`,
+            border: `2px solid ${DEFAULT_BORDER_COLOR}`,
+            color: `${DEFAULT_TEXT_COLOR}`,
           }
         }>
         <span

--- a/src/components/StudyPane/InfoPane/Motif/index.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/index.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 
 import Root from "./Root";
 import Category from "./Category";
+import RelatedWord from "./RelatedWord";
 
 const Motif = ({
    content
@@ -12,7 +13,7 @@ const Motif = ({
    content: PassageData;
   }) => {
 
-  const [openTab, setOpenTab] = useState(MotifType.root);
+  const [openTab, setOpenTab] = useState(MotifType.idc);
 
   const activeClasses = "text-primary border-primary";
   const inactiveClasses = "border-transparent";
@@ -24,11 +25,11 @@ const Motif = ({
         <Link
           href="#"
           className={`border-b-2 pt-4 py-2 text-sm font-medium hover:text-primary md:text-base ${
-            openTab === MotifType.root ? activeClasses : inactiveClasses
+            openTab === MotifType.idc ? activeClasses : inactiveClasses
           }`}
-          onClick={() => setOpenTab(MotifType.root)}
+          onClick={() => setOpenTab(MotifType.idc)}
         >
-          Identical Roots
+          Identical Words
         </Link>
         <Link
           href="#"
@@ -39,10 +40,19 @@ const Motif = ({
         >
           Categories
         </Link>
+        <Link
+          href="#"
+          className={`border-b-2 pt-4 py-2 text-sm font-medium hover:text-primary md:text-base ${
+            openTab === MotifType.rel ? activeClasses : inactiveClasses
+          }`}
+          onClick={() => setOpenTab(MotifType.rel)}
+        >
+          Related Words
+        </Link>
       </div>
       <div className="h-full">
         <div
-          className={`leading-relaxed ${openTab === MotifType.root ? "block" : "hidden"} h-full`}
+          className={`leading-relaxed ${openTab === MotifType.idc ? "block" : "hidden"} h-full`}
         >
           <Root content={content}/>
         </div>
@@ -50,6 +60,11 @@ const Motif = ({
           className={`leading-relaxed ${openTab === MotifType.syn ? "block" : "hidden"} h-full`}
         >
           <Category content={content}/>
+        </div>
+        <div
+          className={`leading-relaxed ${openTab === MotifType.rel ? "block" : "hidden"} h-full`}
+        >
+          <RelatedWord content={content}/>
         </div>
       </div>
     </div>

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -80,6 +80,7 @@ const StudyPane = ({
   const [structureUpdateType, setStructureUpdateType] = useState(StructureUpdateType.none);
   const [rootsColorMap, setRootsColorMap] = useState<Map<number, ColorType>>(new Map());
 
+
   const formatContextValue = {
     ctxStudyId: study.id,
     ctxScaleValue: scaleValue,

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -47,8 +47,6 @@ export const FormatContext = createContext({
   ctxSetStructureUpdateType: (arg: StructureUpdateType) => {},
   ctxRootsColorMap : {} as Map<number, ColorType>,
   ctxSetRootsColorMap : (arg: Map<number, ColorType>) =>{},
-  ctxRelWordsColorMap : {} as Map<string, ColorType>,
-  ctxSetRelWordsColorMap : (arg: Map<string, ColorType>) =>{},
 });
 
 const StudyPane = ({
@@ -81,7 +79,6 @@ const StudyPane = ({
   const [infoPaneAction, setInfoPaneAction] = useState(InfoPaneActionType.none);
   const [structureUpdateType, setStructureUpdateType] = useState(StructureUpdateType.none);
   const [rootsColorMap, setRootsColorMap] = useState<Map<number, ColorType>>(new Map());
-  const [relWordsColorMap, setRelWordsColorMap] = useState<Map<string, ColorType>>(new Map());
 
   const formatContextValue = {
     ctxStudyId: study.id,
@@ -116,8 +113,6 @@ const StudyPane = ({
     ctxSetStropheCount: setStropheCount,
     ctxRootsColorMap: rootsColorMap,
     ctxSetRootsColorMap: setRootsColorMap,
-    ctxRelWordsColorMap: relWordsColorMap,
-    ctxSetRelWordsColorMap: setRelWordsColorMap,
   }
 
 

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -47,6 +47,8 @@ export const FormatContext = createContext({
   ctxSetStructureUpdateType: (arg: StructureUpdateType) => {},
   ctxRootsColorMap : {} as Map<number, ColorType>,
   ctxSetRootsColorMap : (arg: Map<number, ColorType>) =>{},
+  ctxRelWordsColorMap : {} as Map<string, ColorType>,
+  ctxSetRelWordsColorMap : (arg: Map<string, ColorType>) =>{},
 });
 
 const StudyPane = ({
@@ -79,7 +81,7 @@ const StudyPane = ({
   const [infoPaneAction, setInfoPaneAction] = useState(InfoPaneActionType.none);
   const [structureUpdateType, setStructureUpdateType] = useState(StructureUpdateType.none);
   const [rootsColorMap, setRootsColorMap] = useState<Map<number, ColorType>>(new Map());
-
+  const [relWordsColorMap, setRelWordsColorMap] = useState<Map<string, ColorType>>(new Map());
 
   const formatContextValue = {
     ctxStudyId: study.id,
@@ -114,6 +116,8 @@ const StudyPane = ({
     ctxSetStropheCount: setStropheCount,
     ctxRootsColorMap: rootsColorMap,
     ctxSetRootsColorMap: setRootsColorMap,
+    ctxRelWordsColorMap: relWordsColorMap,
+    ctxSetRelWordsColorMap: setRelWordsColorMap,
   }
 
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,7 @@ export enum InfoPaneActionType {
 }
 
 export enum MotifType {
-    root,
+    idc,
     syn,
+    rel,
 }


### PR DESCRIPTION
In this PR:
- add "Related Words" tab in motif, words with the same "root"  form a relation group

todo [in future PRs]:
- cleanup code in identical root tab (rename variables and functions, etc.)
- resolve merge conflicts with Peter's changes on stacked motif 