### PR TITLE
fix disappear title and delete study on cancel delete

### DIFF
--- a/src/components/Modals/DeleteStudy.tsx
+++ b/src/components/Modals/DeleteStudy.tsx
@@ -113,6 +113,7 @@ const DeleteStudyModal = ({
               <div className="w-full px-3 2xsm:w-1/2">
                 <button
                   onClick={() => setModalOpen(false)}
+                  type="button"
                   className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
                 >
                   Cancel

--- a/src/components/StudyPane/Header/Title.tsx
+++ b/src/components/StudyPane/Header/Title.tsx
@@ -51,8 +51,7 @@ const Title = ({ study }:{
     const handleSaveClick = useCallback(() => {
         setIsEditing(false);
         if (!title.trim()) {
-            alert("Error: study title cannot be empty.")
-            setTitle(study.name);
+            setTitle("Untitled Study");
         } else {
             updateStudyName(study.id, title);
         }

--- a/src/components/StudyPane/Header/Title.tsx
+++ b/src/components/StudyPane/Header/Title.tsx
@@ -50,7 +50,7 @@ const Title = ({ study }:{
 
     const handleSaveClick = useCallback(() => {
         setIsEditing(false);
-        if (title.trim() == "") {
+        if (!title.trim()) {
             alert("Error: study title cannot be empty.")
             setTitle(study.name);
         } else {

--- a/src/components/StudyPane/Header/Title.tsx
+++ b/src/components/StudyPane/Header/Title.tsx
@@ -51,7 +51,7 @@ const Title = ({ study }:{
     const handleSaveClick = useCallback(() => {
         setIsEditing(false);
         if (title.trim() == "") {
-            alert("Error: study title can't be empty or blank.")
+            alert("Error: study title cannot be empty.")
             setTitle(study.name);
         } else {
             updateStudyName(study.id, title);

--- a/src/components/StudyPane/Header/Title.tsx
+++ b/src/components/StudyPane/Header/Title.tsx
@@ -50,7 +50,12 @@ const Title = ({ study }:{
 
     const handleSaveClick = useCallback(() => {
         setIsEditing(false);
-        updateStudyName(study.id, title);
+        if (title.trim() == "") {
+            alert("Error: study title can't be empty or blank.")
+            setTitle(study.name);
+        } else {
+            updateStudyName(study.id, title);
+        }
     }, [study.id, title]);
         
     useEffect(() => {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -72,12 +72,6 @@ export async function updateStudyNameWithForm(
   }
   const { studyName } = validatedFields.data;
 
-  if (studyName.trim() == "") {
-    return {
-      message: 'Invalid Name. Study name cannot empty.',
-    };
-  }
-  
   const xataClient = getXataClient();
   try {
     await xataClient.db.study.updateOrThrow({ id: id, name: studyName});

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -72,6 +72,12 @@ export async function updateStudyNameWithForm(
   }
   const { studyName } = validatedFields.data;
 
+  if (studyName.trim() == "") {
+    return {
+      message: 'Invalid Name. Study name cannot empty.',
+    };
+  }
+  
   const xataClient = getXataClient();
   try {
     await xataClient.db.study.updateOrThrow({ id: id, name: studyName});

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -52,35 +52,6 @@ export async function fetchStudyById(studyId: string) {
   }
 }
 
-const UpdateStudyName = RenameFormSchema.omit({ id: true });
-
-export async function updateStudyNameWithForm(
-  id: string,
-  prevState: State,
-  formData: FormData,
-  ) {
-
-  const validatedFields = UpdateStudyName.safeParse({
-    studyName: formData.get('name'),
-  });
-
-  if (!validatedFields.success) {
-    return {
-      errors: validatedFields.error.flatten().fieldErrors,
-      message: 'Missing Fields. Failed to update study.',
-    };
-  }
-  const { studyName } = validatedFields.data;
-
-  const xataClient = getXataClient();
-  try {
-    await xataClient.db.study.updateOrThrow({ id: id, name: studyName});
-  } catch (error) {
-    return { message: 'Database Error: Failed to update study.' };
-  }
-  redirect('/dashboard/home');
-}
-
 export async function updateStudyName(id: string, studyName: string) {
 
   const xataClient = getXataClient();


### PR DESCRIPTION
In this PR:
- Prevent user from saving empty study title in `Title.tsx` and `EditStudy.tsx`
- Fix delete study on `cancel` button clicked in `DeleteStudy.tsx`

To discuss:
`updateStudyNameWithForm` in `src/lib/actions.ts` is no longer used, shall we delete it?

Related Issue:
[86dv888mn](https://app.clickup.com/t/86dv888mn)