### PR TITLE
feat: double click word to select all identical words

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tabler/icons-react": "^2.47.0",
         "@xata.io/client": "^0.29.5",
         "clsx": "^2.1.0",
+        "mitt": "^3.0.1",
         "next": "^14.2.6",
         "react": "^18.3.1",
         "react-color": "^2.19.3",
@@ -3652,6 +3653,11 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tabler/icons-react": "^2.47.0",
     "@xata.io/client": "^0.29.5",
     "clsx": "^2.1.0",
+    "mitt": "^3.0.1",
     "next": "^14.2.6",
     "react": "^18.3.1",
     "react-color": "^2.19.3",

--- a/src/components/StudyPane/InfoPane/Motif/Root.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/Root.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from 'react';
 
-import { PassageData, HebWord, WordProps } from "@/lib/data";
+import { WordProps } from "@/lib/data";
+import { extractIdenticalWordsFromPassage } from "@/lib/utils";
 
 import { RootBlock } from "./RootBlock";
 import RelatedWordSwitcher from "./RelatedWordSwitcher";
@@ -24,24 +25,8 @@ const Root = () => {
     const { ctxPassageProps } = useContext(FormatContext)
     const [selectRelated, setSelectRelated] = useState(false);
 
-    let rootWordsMap = new Map<number, WordProps[]>();
-    ctxPassageProps.stanzaProps.map((stanzas) => {
-        stanzas.strophes.map((strophe) => {
-            strophe.lines.map((line) => {
-                line.words.map((word) => {
-                    const currentWord = rootWordsMap.get(word.strongNumber);
-                    if (currentWord !== undefined) {
-                        currentWord.push(word);
-                    }
-                    else {
-                        rootWordsMap.set(word.strongNumber, [word]);
-                    }
-                })
-            })
-        });
-    })
-
-    let rootWords: RootWordProps[] = [];
+    const rootWordsMap = extractIdenticalWordsFromPassage(ctxPassageProps);
+    const rootWords: RootWordProps[] = [];
     rootWordsMap.forEach((rootWord) => {
         const leadWord = rootWord[0]; 
         if (rootWord.length > 1 && leadWord.strongNumber) {

--- a/src/components/StudyPane/Passage/WordBlock.tsx
+++ b/src/components/StudyPane/Passage/WordBlock.tsx
@@ -1,6 +1,7 @@
 import { WordProps } from '@/lib/data';
 import React, { useState, useEffect, useContext } from 'react';
 import { DEFAULT_COLOR_FILL, DEFAULT_BORDER_COLOR, DEFAULT_TEXT_COLOR, FormatContext } from '../index';
+import { eventBus } from '@/lib/eventBus';
 import { BoxDisplayStyle, ColorActionType, ColorType } from "@/lib/types";
 import { wrapText, wordsHasSameColor } from "@/lib/utils";
 import EsvPopover from './EsvPopover';
@@ -39,6 +40,7 @@ export const WordBlock = ({
   const [textColorLocal, setTextColorLocal] = useState(wordProps.metadata?.color?.text || DEFAULT_TEXT_COLOR);
   const [indentsLocal, setIndentsLocal] = useState(wordProps.metadata?.indent || 0);
   const [selected, setSelected] = useState(false);
+  const [clickTimeout, setClickTimeout] = useState<NodeJS.Timeout | null>(null);
 
   if (ctxColorAction != ColorActionType.none && selected) {
 
@@ -122,6 +124,21 @@ export const WordBlock = ({
 
 
   const handleClick = () => {
+    if (clickTimeout) {
+      clearTimeout(clickTimeout);
+      setClickTimeout(null);
+      handleDoubleClick();
+    } else {
+      const timeout = setTimeout(() => {
+        handleSingleClick();
+        setClickTimeout(null);
+      }, 200);
+      setClickTimeout(timeout);
+    }
+  }
+
+  // select or deselect word block
+  const handleSingleClick = () => {
     setSelected(prevState => !prevState);
     const newSelectedWords = [...ctxSelectedWords]; // Clone the array
     (!selected) ? newSelectedWords.push(wordProps) : newSelectedWords.splice(newSelectedWords.indexOf(wordProps), 1);
@@ -141,8 +158,11 @@ export const WordBlock = ({
         wordsHasSameColor(ctxSelectedWords, ColorActionType.textColor) ? ctxSetTextColor(lastSelectedWord.metadata?.color?.text || DEFAULT_TEXT_COLOR) : ctxSetTextColor(DEFAULT_TEXT_COLOR);
       }
     }
-  }
+  };
 
+  const handleDoubleClick = () => {
+    eventBus.emit("selectAllIdenticalWords", wordProps);
+  }
 
   const verseNumStyles = {
     className: `text-base top-0 ${ctxIsHebrew ? 'right-0' : 'left-0'} sups w-1 position-absolute ${ctxIsHebrew ? 'mr-1' : 'ml-1'}`

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -6,7 +6,8 @@ import { StanzaBlock } from './StanzaBlock';
 import { WordProps } from '@/lib/data';
 import { StructureUpdateType } from '@/lib/types';
 import { updateMetadata } from '@/lib/actions';
-import { mergeData } from '@/lib/utils';
+import { eventBus } from "@/lib/eventBus";
+import { mergeData, extractIdenticalWordsFromPassage } from '@/lib/utils';
 
 import { useDragToSelect } from '@/hooks/useDragToSelect';
 
@@ -197,7 +198,28 @@ const Passage = ({
 
   }, [ctxStructureUpdateType, ctxSelectedWords, ctxSetNumSelectedWords, ctxSetSelectedWords, ctxSetStructureUpdateType]);
   
+  const strongNumWordMap = extractIdenticalWordsFromPassage(ctxPassageProps);
+  useEffect(() => { // handler select/deselect identical words
+    const handler = (word: WordProps) => {
+      const identicalWords = strongNumWordMap.get(word.strongNumber);
+      if (!identicalWords) {
+        return;
+      }
+      const newSelectedHebWords = [...ctxSelectedWords];
 
+      const toSelect = identicalWords.filter(word => newSelectedHebWords.indexOf(word) < 0);
+      if (toSelect.length > 0) { // select all if some are not selected
+        toSelect.forEach(word => newSelectedHebWords.push(word));
+      } else { // deselect if all are selected
+        identicalWords.forEach(word => newSelectedHebWords.splice(newSelectedHebWords.indexOf(word), 1))
+      }
+      ctxSetSelectedWords(newSelectedHebWords);
+      ctxSetNumSelectedWords(newSelectedHebWords.length);
+    };
+
+    eventBus.on("selectAllIdenticalWords", handler);
+    return () => eventBus.off("selectAllIdenticalWords", handler);
+  }, [ctxSelectedWords]);
 
   //console.log(passageProps);
 

--- a/src/lib/eventBus.ts
+++ b/src/lib/eventBus.ts
@@ -1,0 +1,9 @@
+import mitt, { Emitter } from "mitt";
+
+import { WordProps } from "./data";
+
+type Events = {
+    selectAllIdenticalWords: WordProps;
+};
+  
+export const eventBus: Emitter<Events> = mitt<Events>();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -202,6 +202,27 @@ export function parsePassageInfo(inputString: string) : PassageInfo | Error {
   return result;
 }
 
+export function extractIdenticalWordsFromPassage(passageProps : PassageProps) : Map<number, WordProps[]>  {
+  const strongNumWordsMap = new Map<number, WordProps[]>();
+  passageProps.stanzaProps.forEach((stanzas) => {
+    stanzas.strophes.forEach((strophe) => {
+        strophe.lines.forEach((line) => {
+            line.words.forEach((word) => {
+                const currentWord = strongNumWordsMap.get(word.strongNumber);
+                if (currentWord !== undefined) {
+                    currentWord.push(word);
+                }
+                else {
+                  strongNumWordsMap.set(word.strongNumber, [word]);
+                }
+            })
+        })
+    });
+  });
+
+  return strongNumWordsMap;
+}
+
 function measureStringWidth(context: CanvasRenderingContext2D, text: string): number {
   // Measure the width of the text
   const metrics = context.measureText(text);


### PR DESCRIPTION
In this PR:
- Double-click a word block will trigger a `selectAllIdenticalWords` event, which will be handled in `Passage.tsx` 
  - If all identical words have not been selected, they will be selected
  - If some identical words have been selected and some not, those not selected will be selected
  - If all identical words have been selected, they will be deselected 
- rename and refactor `HebWordProps`, extract identical words and related words logic in `Root.tsx`, moved the refactor function to utils

To do:
- shall we fully refactor `Root` and `RootBlock` in this PR? The naming may be confusing.

Notes:
- will merge this PR after `styling_database` is merged into main