### PR TITLE
fix bug unwanted space when zooming out on passage

### DIFF
--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -229,6 +229,7 @@ const Passage = ({
       onMouseDown={handleMouseDown}
       ref={containerRef}
       style={{ WebkitUserSelect: 'text', userSelect: 'text' }}
+      className="h-0"
     >
       <div id="selaPassage" className='flex relative py-4'>
         {


### PR DESCRIPTION
We zoom in/out on `selaPassage` div, so we need to set the parent div to be `h-0`. Otherwise, when we zoom out on the passage content, the height of `selaPassage` decreases, but the height of the parent div remains the same, causing extra space at the end.