### PR TITLE
Fixing issue #86dvrpd26 with hover bug

### DIFF
--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -17,7 +17,7 @@ import { updateMetadata } from "@/lib/actions";
 
 export const ToolTip = ({ text }: { text: string }) => {
   return (
-    <div className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap rounded bg-black px-4.5 py-1.5 text-xs text-white opacity-0 group-hover:opacity-100">
+    <div className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap rounded bg-black px-4.5 py-1.5 text-xs text-white opacity-0 group-hover:opacity-100 hover:!opacity-0">
       <span className="absolute left-1/2 top-[-3px] -z-10 h-2 w-2 -translate-x-1/2 rotate-45 rounded-sm bg-black"></span>
       {text}
     </div>


### PR DESCRIPTION
Fixing the hover issue which seems to be caused by group-hover also setting a hover state on the hidden tooltip. Fixed this by adding a hover:!opacity-0 to the tooltip div. There may be a better way to do this, but this seems to be the simplest solution while still following the design of the component.