### PR TITLE
Revising fix to use pointer-events-none to also solve the collapse button issue raised in Toby's testing

### DIFF
--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -17,7 +17,7 @@ import { updateMetadata } from "@/lib/actions";
 
 export const ToolTip = ({ text }: { text: string }) => {
   return (
-    <div className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap rounded bg-black px-4.5 py-1.5 text-xs text-white opacity-0 group-hover:opacity-100 hover:!opacity-0">
+    <div className="absolute left-1/2 top-full mt-3 -translate-x-1/2 whitespace-nowrap rounded bg-black px-4.5 py-1.5 text-xs text-white opacity-0 group-hover:opacity-100 pointer-events-none">
       <span className="absolute left-1/2 top-[-3px] -z-10 h-2 w-2 -translate-x-1/2 rotate-45 rounded-sm bg-black"></span>
       {text}
     </div>


### PR DESCRIPTION
Revised the previous fix to use pointer-events-none rather than just keeping the opacity-0. This prevents the tooltip from covering up the collapse button (or anything else that it covers). 