### PR TITLE
fix timezone bug in recent table

### DIFF
--- a/src/components/Tables/Public.tsx
+++ b/src/components/Tables/Public.tsx
@@ -1,5 +1,4 @@
 import { getXataClient } from '@/xata';
-import { formatToLocalTime } from '@/lib/utils';
 import { currentUser, clerkClient } from '@clerk/nextjs';
 import Image from 'next/image'
 
@@ -104,12 +103,12 @@ export default async function PublicTable({
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark">
                   <p className="text-black dark:text-white">
-                    {formatToLocalTime(studyItem.xata.createdAt)}
+                    {studyItem.xata.createdAt.toLocaleString()}
                   </p>
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark">
                   <p className="text-black dark:text-white">
-                    {formatToLocalTime(studyItem.xata.updatedAt)}
+                    {studyItem.xata.updatedAt.toLocaleString()}
                   </p>
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark flex items-center">

--- a/src/components/Tables/Recent.tsx
+++ b/src/components/Tables/Recent.tsx
@@ -97,12 +97,12 @@ export default function RecentTable({
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark">
                   <p className="text-black dark:text-white">
-                    {studyItem.createdAt}
+                    {studyItem.createdAt?.toLocaleString()}
                   </p>
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark">
                   <p className="text-black dark:text-white">
-                    {studyItem.lastUpdated}
+                    {studyItem.lastUpdated?.toLocaleString()}
                   </p>
                 </td>
                 <td className="border-b border-[#eee] py-5 px-4 dark:border-strokedark">

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -7,7 +7,7 @@ import { getXataClient, StudyRecord, HebBibleRecord } from '@/xata';
 import { ge, le } from "@xata.io/client";
 import { currentUser } from '@clerk/nextjs';
 
-import { formatToLocalTime, parsePassageInfo } from './utils';
+import { parsePassageInfo } from './utils';
 import { StudyData, PassageData, PassageStaticData, StudyProps, PassageProps, StudyMetadata, WordProps, StropheData, HebWord, StanzaData, FetchStudiesResult } from './data';
 
 const RenameFormSchema = z.object({
@@ -527,8 +527,8 @@ export async function fetchRecentStudies(query: string, currentPage: number, sor
     searchResult.records.push({
       id: studyRecord.id, name: studyRecord.name, owner: user?.id, passage: studyRecord.passage, 
       public: studyRecord.public || false, starred: studyRecord.starred || false,
-      lastUpdated: formatToLocalTime(studyRecord.xata.updatedAt), 
-      createdAt: formatToLocalTime(studyRecord.xata.createdAt), 
+      lastUpdated: studyRecord.xata.updatedAt, 
+      createdAt: studyRecord.xata.createdAt, 
       metadata: studyRecord.metadata })
   });
   searchResult.totalPages = Math.ceil(dbQuery.length/PAGINATION_SIZE);
@@ -564,7 +564,7 @@ export async function fetchModelStudies(query: string, currentPage: number) {
     searchResult.records.push({
       id: studyRecord.id, name: studyRecord.name, owner: user?.id, passage: studyRecord.passage, 
       public: studyRecord.public || false, starred: studyRecord.starred || false,
-      lastUpdated: formatToLocalTime(studyRecord.xata.updatedAt), metadata: studyRecord.metadata })
+      lastUpdated: studyRecord.xata.updatedAt, metadata: studyRecord.metadata })
   });
   searchResult.totalPages = Math.ceil(search.totalCount/PAGINATION_SIZE);
   return searchResult;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -121,8 +121,8 @@ export interface StudyData {
     public: boolean;
     starred?: boolean;
     model?: boolean;
-    lastUpdated?: string;
-    createdAt?: string;
+    lastUpdated?: Date;
+    createdAt?: Date;
     metadata: StudyMetadata;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -424,8 +424,3 @@ export const mergeData = (bibleData: WordProps[], studyMetadata : StudyMetadata)
 
   return passageProps;
 }
-
-export const formatToLocalTime = (date: Date) => {
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  return date.toLocaleString("en-US", { timeZone });
-};


### PR DESCRIPTION
- remove `formatToLocalTime`, `(new Date()).toLocaleString()` is enough to display time in the local timezone
- because `Recent.tsx` is a client component, we should call `.toLocaleString()` in the component, not the action function (the fetch data in `useEffect` runs on the server side)

Will fix `Public.tsx` next. Need to refactor it into a client component.