### PR TITLE
fixed border width for default color

### DIFF
--- a/src/components/StudyPane/Passage/WordBlock.tsx
+++ b/src/components/StudyPane/Passage/WordBlock.tsx
@@ -43,8 +43,7 @@ export const WordBlock = ({
   const [selected, setSelected] = useState(false);
   const [clickTimeout, setClickTimeout] = useState<NodeJS.Timeout | null>(null);
 
-  if (ctxColorAction != ColorActionType.none) {
-
+  if (ctxColorAction != ColorActionType.none ) {
     ctxRootsColorMap.delete(wordProps.strongNumber);
 
     const colorUpdates: Partial<typeof wordProps.metadata.color> = {};
@@ -150,6 +149,15 @@ export const WordBlock = ({
     }
   }, [ctxSelectedWords, ctxSetColorFill, ctxSetBorderColor, ctxSetTextColor]);
 
+  useEffect(() => {
+  }, [borderColorLocal]);
+
+  useEffect(() => {
+  }, [selected]);
+
+  useEffect(() => {
+  }, [ctxColorAction]);
+
   const handleClick = () => {
     if (clickTimeout) {
       clearTimeout(clickTimeout);
@@ -221,20 +229,24 @@ export const WordBlock = ({
     }
   }
 
+  const isDefaultBorderColor = (color: string) => {
+    const normalizedColor = (color.startsWith('#') ? color : `#${color}`).toLowerCase();
+    const normalizedDefault = DEFAULT_BORDER_COLOR.toLowerCase();
+    return normalizedColor === normalizedDefault;
+  };
+
   const renderIndents = (times: number) => {
     return (
       <div className="flex">
         {[...Array(times)].map((_, i) => (
           <div
             key={i}
-            className={`wordBlock mx-1 select-none rounded border outline-offset-[-4px]'}`}
-            style={
-              {
-                boxSizing: 'border-box',
-                border: `${borderColorLocal !== DEFAULT_BORDER_COLOR ? '3px' : '2px'} solid transparent`,
-                padding: `${borderColorLocal !== DEFAULT_BORDER_COLOR ? '1px' : '2px'}`,
-              }
-            }>
+            className={`wordBlock mx-1 select-none rounded border outline-offset-[-4px]`}
+            style={{
+              boxSizing: 'border-box',
+              border: `${isDefaultBorderColor(borderColorLocal) ? '2px' : '3px'} solid transparent`,
+              padding: `${isDefaultBorderColor(borderColorLocal) ? '2px' : '1px'}`,
+            }}>
             <span className="flex select-none">
               {<sup {...verseNumStyles}></sup>}
               <span className={`whitespace-nowrap break-keep flex select-none px-2 py-1 items-center justify-center text-center leading-none ${fontSize}
@@ -254,15 +266,13 @@ export const WordBlock = ({
         id={wordProps.wordId.toString()}
         key={wordProps.wordId}
         className={`wordBlock mx-1 ${selected ? 'rounded border outline outline-offset-1 outline-[3px] outline-[#FFC300] drop-shadow-md' : 'rounded border outline-offset-[-4px]'}`}
-        style={
-          {
-            background: `${colorFillLocal}`,
-            boxSizing: 'border-box',
-            border: `${borderColorLocal !== DEFAULT_BORDER_COLOR ? '3px' : '2px'} solid ${borderColorLocal}`,
-            padding: `${borderColorLocal !== DEFAULT_BORDER_COLOR ? '1px' : '2px'}`,
-            color: `${textColorLocal}`,
-          }
-        }>
+        style={{
+          background: colorFillLocal,
+          boxSizing: 'border-box',
+          border: `${isDefaultBorderColor(borderColorLocal) ? '2px' : '3px'} solid ${borderColorLocal}`,
+          padding: `${isDefaultBorderColor(borderColorLocal) ? '2px' : '1px'}`,
+          color: textColorLocal,
+        }}>
         <span
           className="flex"
           onClick={handleClick}


### PR DESCRIPTION
The fix was fairly simple but took me forever to find. Might be a good to know thing, so when comparing colors, the default color from our code base are all upper case letter, but the hex from the color pallet are all in lower case, thus causing the comparison to fail. 