### PR TITLE
add null check to motifData before reading its properties

### DIFF
--- a/src/components/StudyPane/InfoPane/Motif/IdenticalWord.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/IdenticalWord.tsx
@@ -34,7 +34,7 @@ const IdenticalWord = () => {
         if (words.length > 1 && leadWord.strongNumber) {
             // use wordProps.motifData.relatedStrongNums to find the related words in the study
             const relatedWords:WordProps[] = [];
-            if (leadWord.motifData.relatedStrongNums && leadWord.motifData.relatedStrongNums.length > 0) {
+            if (leadWord.motifData?.relatedStrongNums && leadWord.motifData.relatedStrongNums.length > 0) {
                 leadWord.motifData.relatedStrongNums.forEach(strongNum => {
                     strongNumToWordsMap.get(strongNum)?.forEach(word => relatedWords.push(word));
                 });

--- a/src/components/StudyPane/InfoPane/Motif/IdenticalWordBlock.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/IdenticalWordBlock.tsx
@@ -161,7 +161,7 @@ export const IdenticalWordBlock = ({
             // TODO: remove motifData.relatedWords, this might be a typo, we should display the Hebrew of the identical word, 
             // not the related words of the identical word. Plus, may also consider refactor identicalWords[0].ETCBCgloss,
             // i.e. use motifData.lexicon.lemma / motifData.lexicon.gloss
-          >{ctxIsHebrew ? identicalWords[0].motifData.relatedWords?.lemma : identicalWords[0].ETCBCgloss}</span>
+          >{ctxIsHebrew ? identicalWords[0].motifData?.relatedWords?.lemma : identicalWords[0].ETCBCgloss}</span>
           <span className="flex h-6.5 w-full min-w-6.5 max-w-6.5 items-center justify-center rounded-full bg-[#EFEFEF] text-black text-sm">{count}</span>
         </span>
       </div>


### PR DESCRIPTION
Some words in dev db don't have motif data, and directly calling word.motifData.relatedStrongNums will break the service.