### PR TITLE
refactor: centralize modal component for reusability

### DIFF
--- a/src/components/Modals/CloneStudy.tsx
+++ b/src/components/Modals/CloneStudy.tsx
@@ -1,6 +1,7 @@
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { FormEvent, useState } from 'react';
 import { cloneStudy } from '@/lib/actions';
 import { StudyData } from '@/lib/data';
+import Modal from '../common/Modal';
 
 interface CloneStudyModalProps {
     originalStudy: StudyData;
@@ -9,42 +10,29 @@ interface CloneStudyModalProps {
 }
 
 export default function CloneStudyModal({ originalStudy, open, setOpen }: CloneStudyModalProps) {
-
     const [clonedStudyName, setClonedStudyName] = useState("Copy of " + originalStudy.name.trimEnd());
-    const [isLoading, setIsLoading] = useState<boolean>(false)
-    const [error, setError] = useState<string | null>(null)
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
 
-    const modal = useRef<any>(null);
-    const inputRef = useRef<HTMLInputElement>(null);
-    
-    const onCancel = () => {
-        setClonedStudyName("");
+    const handleClose = () => {
         setOpen(false);
         setError(null);
-    }
+    };
 
-    // close if the esc key is pressed
-    useEffect(() => {
-      const keyHandler = ({ key }: KeyboardEvent) => {
-        if (!open || key !== "Escape") return;
-        setOpen(false);
-      };
-      document.addEventListener("keydown", keyHandler);
-      return () => document.removeEventListener("keydown", keyHandler);
-    });
+    const onCancel = () => {
+        setClonedStudyName('');
+        handleClose();
+    };
 
     async function onSubmit(event: FormEvent<HTMLFormElement>) {
-
         event.preventDefault();
         setIsLoading(true);
         setError(null); // Clear previous errors when a new request starts
-        setOpen(false);
-
+        handleClose();
         try {
             cloneStudy(originalStudy, clonedStudyName);
             setClonedStudyName('');
         } catch (e) {
-            // Capture the error message to display to the user
             setError((e as Error).message);
             console.error(e);
         } finally {
@@ -53,65 +41,55 @@ export default function CloneStudyModal({ originalStudy, open, setOpen }: CloneS
     }
 
     return (
-        <div
-            className={`fixed left-0 top-0 z-999999 flex h-full min-h-screen w-full items-center justify-center bg-black/90 px-4 py-5 ${open ? "block" : "hidden"
-                }`}
-        >
-            <div
-                ref={modal}
-                onFocus={() => setOpen(true)}
-                className="w-full max-w-142.5 rounded-lg bg-white px-8 py-12 text-center dark:bg-boxdark md:px-17.5 md:py-15"
-            >
-                <h3 className="pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
-                    Rename your study to...
-                </h3>
-                <span className="mx-auto mb-6 inline-block h-1 w-22.5 rounded bg-primary"></span>
-                <form onSubmit={onSubmit}>
-                    <input
-                        ref={inputRef}
-                        type="text"
-                        min={2}
-                        max={50}
-                        defaultValue={clonedStudyName}
-                        onChange={e => { setClonedStudyName(e.target.value) }}
-                        name="studyName"
-                        id="studyName"
-                        className="w-full rounded-lg border-[2px] border-primary bg-transparent px-5 py-3 text-black outline-none transition focus:border-primary active:border-primary disabled:cursor-default disabled:bg-whiter dark:bg-form-input dark:text-white"
-                    />
+        <Modal open={open} onClose={handleClose}>
+            <h3 className="pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
+                Rename your study to...
+            </h3>
+            <span className="mx-auto mb-6 inline-block h-1 w-22.5 rounded bg-primary"></span>
+            <form onSubmit={onSubmit}>
+                <input
+                    type="text"
+                    min={2}
+                    max={50}
+                    defaultValue={clonedStudyName}
+                    onChange={e => setClonedStudyName(e.target.value)}
+                    name="studyName"
+                    id="studyName"
+                    className="w-full rounded-lg border-[2px] border-primary bg-transparent px-5 py-3 text-black outline-none transition focus:border-primary active:border-primary disabled:cursor-default disabled:bg-whiter dark:bg-form-input dark:text-white"
+                />
 
-                    <div className="-mx-3 my-10 flex flex-wrap gap-y-4">
-                        <div className="w-full px-3 2xsm:w-1/2">
-                            <button type="reset"
-                                onClick={() => {
-                                    onCancel();
-                                }}
-                                className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                        <div className="w-full px-3 2xsm:w-1/2">
-                            <button type="submit"
-                                className="block w-full rounded border border-primary bg-primary p-3 text-center font-medium text-white transition hover:bg-opacity-90"
-                            >
-                                {isLoading ? 'Loading...' : 'OK'}
-                            </button>
-                        </div>
+                <div className="-mx-3 my-10 flex flex-wrap gap-y-4">
+                    <div className="w-full px-3 2xsm:w-1/2">
+                        <button
+                            type="reset"
+                            onClick={onCancel}
+                            className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
+                        >
+                            Cancel
+                        </button>
                     </div>
-                </form>
-                {error ?
-                    <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative">
-                        <span className="block sm:inline">{error}</span>
-                        <span className="absolute top-0 bottom-0 right-0 px-4 py-3">
-                            <button onClick={()=>{setError(null)}}>
-                                <svg className="fill-current h-6 w-6 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" /></svg>
-                            </button>
-                        </span>
-                    </div> : <div></div>
-                }
-            </div>
-     </div>
-
-    )
+                    <div className="w-full px-3 2xsm:w-1/2">
+                        <button
+                            type="submit"
+                            className="block w-full rounded border border-primary bg-primary p-3 text-center font-medium text-white transition hover:bg-opacity-90"
+                        >
+                            {isLoading ? 'Loading...' : 'OK'}
+                        </button>
+                    </div>
+                </div>
+            </form>
+            {error ? (
+                <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative">
+                    <span className="block sm:inline">{error}</span>
+                    <span className="absolute top-0 bottom-0 right-0 px-4 py-3">
+                        <button onClick={() => setError(null)}>
+                            <svg className="fill-current h-6 w-6 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" /></svg>
+                        </button>
+                    </span>
+                </div>
+            ) : (
+                <div></div>
+            )}
+        </Modal>
+    );
 }
-

--- a/src/components/Modals/DeleteStudy.tsx
+++ b/src/components/Modals/DeleteStudy.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { FormEvent, useEffect, useRef, useState } from 'react'
-
+import { FormEvent, useState } from 'react';
 import { IconTrash } from "@tabler/icons-react";
-
 import { deleteStudy } from '@/lib/actions';
 import { StudyData } from '@/lib/data';
+import Modal from '../common/Modal';
 
 const DeleteStudyModal = ({
   studyItem,
@@ -14,11 +13,7 @@ const DeleteStudyModal = ({
   studyItem: StudyData;
   setTriggerFetch: (arg: boolean) => void;
 } ) => {
-
   const [modalOpen, setModalOpen] = useState(false);
-
-  const trigger = useRef<any>(null);
-  const modal = useRef<any>(null);
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -32,104 +27,66 @@ const DeleteStudyModal = ({
     }
   }
 
-  // close on click outside
-  useEffect(() => {
-    const clickHandler = ({ target }: MouseEvent) => {
-      if (!modal.current) return;
-      if (
-        !modalOpen ||
-        modal.current.contains(target) ||
-        trigger.current.contains(target)
-      )
-        return;
-      setModalOpen(false);
-    };
-    document.addEventListener("click", clickHandler);
-    return () => document.removeEventListener("click", clickHandler);
-  });
-
-  // close if the esc key is pressed
-  useEffect(() => {
-    const keyHandler = ({ keyCode }: KeyboardEvent) => {
-      if (!modalOpen || keyCode !== 27) return;
-      setModalOpen(false);
-    };
-    document.addEventListener("keydown", keyHandler);
-    return () => document.removeEventListener("keydown", keyHandler);
-  });
-
   return (
     <>
-      <button 
+      <button
         className="hover:text-primary"
-        ref={trigger}
-        onClick={() => setModalOpen(!modalOpen)} >
+        onClick={() => setModalOpen(true)} >
         <IconTrash />
       </button>
 
-      <div
-        className={`fixed left-0 top-0 z-999999 flex h-full min-h-screen w-full items-center justify-center bg-black/90 px-4 py-5 ${
-          modalOpen ? "block" : "hidden"
-        }`}
-      >
-        <div
-          ref={modal}
-          onFocus={() => setModalOpen(true)}
-          onBlur={() => setModalOpen(false)}
-          className="w-full max-w-142.5 rounded-lg bg-white px-8 py-12 text-center dark:bg-boxdark md:px-17.5 md:py-15"
-        >
-          <span className="mx-auto inline-block">
-            <svg
+      <Modal open={modalOpen} onClose={() => setModalOpen(false)}>
+        <span className="mx-auto inline-block">
+          <svg
+            width="60"
+            height="60"
+            viewBox="0 0 60 60"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              opacity="0.1"
               width="60"
               height="60"
-              viewBox="0 0 60 60"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <rect
-                opacity="0.1"
-                width="60"
-                height="60"
-                rx="30"
-                fill="#DC2626"
-              />
-              <path
-                d="M30 27.2498V29.9998V27.2498ZM30 35.4999H30.0134H30ZM20.6914 41H39.3086C41.3778 41 42.6704 38.7078 41.6358 36.8749L32.3272 20.3747C31.2926 18.5418 28.7074 18.5418 27.6728 20.3747L18.3642 36.8749C17.3296 38.7078 18.6222 41 20.6914 41Z"
-                stroke="#DC2626"
-                strokeWidth="2.2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </span>
-          <h3 className="mt-5.5 pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
-            &ldquo;{studyItem.name}&rdquo;
-          </h3>
-          <p className="mb-10">
-            Are you sure you want to delete this study permanently?
-          </p>
-          <form onSubmit={onSubmit}>
-            <div className="-mx-3 flex flex-wrap gap-y-4">
-              <div className="w-full px-3 2xsm:w-1/2">
-                <button
-                  onClick={() => setModalOpen(false)}
-                  type="button"
-                  className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
-                >
-                  Cancel
-                </button>
-              </div>
-              <div className="w-full px-3 2xsm:w-1/2">
-                <button type="submit"
-                  className="block w-full rounded border border-primary bg-primary p-3 text-center font-medium text-white transition hover:bg-opacity-90"
-                >
-                  Delete
-                </button>
-              </div>
+              rx="30"
+              fill="#DC2626"
+            />
+            <path
+              d="M30 27.2498V29.9998V27.2498ZM30 35.4999H30.0134H30ZM20.6914 41H39.3086C41.3778 41 42.6704 38.7078 41.6358 36.8749L32.3272 20.3747C31.2926 18.5418 28.7074 18.5418 27.6728 20.3747L18.3642 36.8749C17.3296 38.7078 18.6222 41 20.6914 41Z"
+              stroke="#DC2626"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+        <h3 className="mt-5.5 pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
+          &ldquo;{studyItem.name}&rdquo;
+        </h3>
+        <p className="mb-10">
+          Are you sure you want to delete this study permanently?
+        </p>
+        <form onSubmit={onSubmit}>
+          <div className="-mx-3 flex flex-wrap gap-y-4">
+            <div className="w-full px-3 2xsm:w-1/2">
+              <button
+                onClick={() => setModalOpen(false)}
+                type="button"
+                className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
+              >
+                Cancel
+              </button>
             </div>
-          </form>
-        </div>
-      </div>
+            <div className="w-full px-3 2xsm:w-1/2">
+              <button type="submit"
+                className="block w-full rounded border border-primary bg-primary p-3 text-center font-medium text-white transition hover:bg-opacity-90"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </form>
+      </Modal>
     </>
   );
 };

--- a/src/components/Modals/EditStudy.tsx
+++ b/src/components/Modals/EditStudy.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { FormEvent, useState, useRef } from "react";
+import { FormEvent, useState } from "react";
 import { IconEdit } from "@tabler/icons-react";
 import { updateStudyName } from '@/lib/actions';
+import Modal from '../common/Modal';
 
 const EditStudyModal = ({
   studyId,
   studyName,
-  setTriggerFetch
+  setTriggerFetch,
 }: {
   studyId: string;
   studyName: string;
@@ -15,9 +16,6 @@ const EditStudyModal = ({
 } ) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const trigger = useRef<any>(null);
-  const modal = useRef<any>(null);
 
   const onCancel = () => {
     setModalOpen(false);
@@ -44,31 +42,20 @@ const EditStudyModal = ({
 
   return (
     <>
-      <button 
+      <button
         className="hover:text-primary"
-        ref={trigger}
         onClick={() => {
             setModalOpen(true);
         }} >
         <IconEdit />
       </button>
-
-      <div
-        className={`fixed left-0 top-0 z-999999 flex h-full min-h-screen w-full items-center justify-center bg-black/90 px-4 py-5 ${
-          modalOpen ? "block" : "hidden"
-        }`}
-      >
-        <div
-          ref={modal}
-          onFocus={() => setModalOpen(true)}
-          className="w-full max-w-142.5 rounded-lg bg-white px-8 py-12 text-center dark:bg-boxdark md:px-17.5 md:py-15"
-        >
+      <Modal open={modalOpen} onClose={onCancel}>
           <h3 className="pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
             Rename to
           </h3>
           <span className="mx-auto mb-6 inline-block h-1 w-22.5 rounded bg-primary"></span>
             <form onSubmit={onSubmit}>
-              <input type="hidden" name="id" value={studyId} />  
+              <input type="hidden" name="id" value={studyId} />
               <input
                 type="text"
                 min={2}
@@ -107,8 +94,7 @@ const EditStudyModal = ({
                   </span>
               </div> : <div></div>
             }
-        </div>
-      </div>
+      </Modal>
     </>
   );
 };

--- a/src/components/Modals/NewStudy.tsx
+++ b/src/components/Modals/NewStudy.tsx
@@ -1,6 +1,7 @@
-import { FormEvent, useEffect, useRef, useState } from 'react'
+import { FormEvent, useState } from 'react';
 import { createStudy } from '@/lib/actions';
 import { parsePassageInfo } from '@/lib/utils';
+import Modal from '../common/Modal';
 
 interface NewStudyModalProps {
     open: boolean;
@@ -8,30 +9,21 @@ interface NewStudyModalProps {
 }
 
 export default function NewStudyModal({ open, setOpen }: NewStudyModalProps) {
-
     const [passage, setPassage] = useState('');
-    const modal = useRef<any>(null);
-    const [isLoading, setIsLoading] = useState<boolean>(false)
-    const [error, setError] = useState<string | null>(null)
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [error, setError] = useState<string | null>(null);
 
-    const onCancel = () => {
-        setPassage("");
+    const handleClose = () => {
         setOpen(false);
         setError(null);
-    }
+    };
 
-    // close if the esc key is pressed
-    useEffect(() => {
-      const keyHandler = ({ key }: KeyboardEvent) => {
-        if (!open || key !== "Escape") return;
-        setOpen(false);
-      };
-      document.addEventListener("keydown", keyHandler);
-      return () => document.removeEventListener("keydown", keyHandler);
-    });
+    const onCancel = () => {
+        setPassage('');
+        handleClose();
+    };
 
     async function onSubmit(event: FormEvent<HTMLFormElement>) {
-
         event.preventDefault();
         setIsLoading(true);
         setError(null); // Clear previous errors when a new request starts
@@ -41,13 +33,12 @@ export default function NewStudyModal({ open, setOpen }: NewStudyModalProps) {
             setIsLoading(false);
             return;
         } else {
-            setOpen(false);
+            handleClose();
             setPassage('');
         }
         try {
             createStudy(passage);
         } catch (e) {
-            // Capture the error message to display to the user
             setError((e as Error).message);
             console.error(e);
         } finally {
@@ -56,65 +47,56 @@ export default function NewStudyModal({ open, setOpen }: NewStudyModalProps) {
     }
 
     return (
-        <div
-            className={`fixed left-0 top-0 z-999999 flex h-full min-h-screen w-full items-center justify-center bg-black/90 px-4 py-5 ${open ? "block" : "hidden"
-                }`}
-        >
-            <div
-                ref={modal}
-                onFocus={() => setOpen(true)}
-                className="w-full max-w-142.5 rounded-lg bg-white px-8 py-12 text-center dark:bg-boxdark md:px-17.5 md:py-15"
-            >
-                <h3 className="pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
-                    Start a study in Psalm...
-                </h3>
-                <span className="mx-auto mb-6 inline-block h-1 w-22.5 rounded bg-primary"></span>
-                <form onSubmit={onSubmit}>
-                    <input
-                        type="text"
-                        min={2}
-                        max={50}
-                        value={passage}
-                        onChange={e => { setPassage(e.target.value) }}
-                        name="passage"
-                        id="passage"
-                        placeholder="23:1-5"
-                        className="w-full rounded-lg border-[2px] border-primary bg-transparent px-5 py-3 text-black outline-none transition focus:border-primary active:border-primary disabled:cursor-default disabled:bg-whiter dark:bg-form-input dark:text-white"
-                    />
+        <Modal open={open} onClose={handleClose}>
+            <h3 className="pb-2 text-xl font-bold text-black dark:text-white sm:text-2xl">
+                Start a study in Psalm...
+            </h3>
+            <span className="mx-auto mb-6 inline-block h-1 w-22.5 rounded bg-primary"></span>
+            <form onSubmit={onSubmit}>
+                <input
+                    type="text"
+                    min={2}
+                    max={50}
+                    value={passage}
+                    onChange={e => setPassage(e.target.value)}
+                    name="passage"
+                    id="passage"
+                    placeholder="23:1-5"
+                    className="w-full rounded-lg border-[2px] border-primary bg-transparent px-5 py-3 text-black outline-none transition focus:border-primary active:border-primary disabled:cursor-default disabled:bg-whiter dark:bg-form-input dark:text-white"
+                />
 
-                    <div className="-mx-3 my-10 flex flex-wrap gap-y-4">
-                        <div className="w-full px-3 2xsm:w-1/2">
-                            <button type="reset"
-                                onClick={() => {
-                                    onCancel();
-                                }}
-                                className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                        <div className="w-full px-3 2xsm:w-1/2">
-                            <button type="submit"
-                                className="block w-full rounded border border-primary bg-primary p-3 text-center font-medium text-white transition hover:bg-opacity-90"
-                            >
-                                {isLoading ? 'Loading...' : 'OK'}
-                            </button>
-                        </div>
+                <div className="-mx-3 my-10 flex flex-wrap gap-y-4">
+                    <div className="w-full px-3 2xsm:w-1/2">
+                        <button
+                            type="reset"
+                            onClick={onCancel}
+                            className="block w-full rounded border border-stroke bg-gray p-3 text-center font-medium text-black transition hover:border-meta-1 hover:bg-meta-1 hover:text-white dark:border-strokedark dark:bg-meta-4 dark:text-white dark:hover:border-meta-1 dark:hover:bg-meta-1"
+                        >
+                            Cancel
+                        </button>
                     </div>
-                </form>
-                {error ?
-                    <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative">
-                        <span className="block sm:inline">{error}</span>
-                        <span className="absolute top-0 bottom-0 right-0 px-4 py-3">
-                            <button onClick={()=>{setError(null)}}>
-                                <svg className="fill-current h-6 w-6 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" /></svg>
-                            </button>
-                        </span>
-                    </div> : <div></div>
-                }
-            </div>
-     </div>
-
-    )
+                    <div className="w-full px-3 2xsm:w-1/2">
+                        <button
+                            type="submit"
+                            className="block w-full rounded border border-primary bg-primary p-3 text-center font-medium text-white transition hover:bg-opacity-90"
+                        >
+                            {isLoading ? 'Loading...' : 'OK'}
+                        </button>
+                    </div>
+                </div>
+            </form>
+            {error ? (
+                <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg relative">
+                    <span className="block sm:inline">{error}</span>
+                    <span className="absolute top-0 bottom-0 right-0 px-4 py-3">
+                        <button onClick={() => setError(null)}>
+                            <svg className="fill-current h-6 w-6 text-red-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z" /></svg>
+                        </button>
+                    </span>
+                </div>
+            ) : (
+                <div></div>
+            )}
+        </Modal>
+    );
 }
-

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,39 @@
+import { ReactNode, useEffect } from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  className?: string;
+}
+
+const Modal = ({ open, onClose, children, className = '' }: ModalProps) => {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && open) {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed left-0 top-0 z-999999 flex h-full min-h-screen w-full items-center justify-center bg-black/90 px-4 py-5"
+      onClick={onClose}
+    >
+      <div
+        className={`w-full max-w-142.5 rounded-lg bg-white px-8 py-12 text-center dark:bg-boxdark md:px-17.5 md:py-15 ${className}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;
+


### PR DESCRIPTION
## Summary
- add reusable `Modal` component to unify modal behavior
- refactor study modals to use shared component and reduce duplication

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bc9229fe788325be5a19e84568f763