### PR TITLE
chore: remove deprecated motifData.relatedWords

### DIFF
--- a/src/components/StudyPane/InfoPane/Motif/IdenticalWordBlock.tsx
+++ b/src/components/StudyPane/InfoPane/Motif/IdenticalWordBlock.tsx
@@ -161,7 +161,7 @@ export const IdenticalWordBlock = ({
             // TODO: remove motifData.relatedWords, this might be a typo, we should display the Hebrew of the identical word, 
             // not the related words of the identical word. Plus, may also consider refactor identicalWords[0].ETCBCgloss,
             // i.e. use motifData.lexicon.lemma / motifData.lexicon.gloss
-          >{ctxIsHebrew ? identicalWords[0].motifData?.relatedWords?.lemma : identicalWords[0].ETCBCgloss}</span>
+          >{ctxIsHebrew ? identicalWords[0].motifData?.lemma : identicalWords[0].ETCBCgloss}</span>
           <span className="flex h-6.5 w-full min-w-6.5 max-w-6.5 items-center justify-center rounded-full bg-[#EFEFEF] text-black text-sm">{count}</span>
         </span>
       </div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -653,7 +653,7 @@ export async function fetchPassageData(studyId: string) {
           .filter("chapter", le(passageInfo.endChapter))
           .filter("verse", ge(passageInfo.startVerse))
           .filter("verse", le(passageInfo.endVerse))
-          .select(["*", "motifLink.categories", "motifLink.relatedLink.*", "motifLink.lemmaLink.lemma", "motifLink.relatedStrongCodes"])
+          .select(["*", "motifLink.categories", "motifLink.lemmaLink.lemma", "motifLink.relatedStrongCodes"])
           .sort("hebId", "asc")
           .getAll();
 
@@ -675,12 +675,7 @@ export async function fetchPassageData(studyId: string) {
             const relatedStrongNums = word.motifLink?.relatedStrongCodes?.map(code => parseInt(code))
                                         .filter(code => strongNumberSet.has(code) && code != word.strongNumber);
             hebWord.motifData = {
-              //lemma: word.motifLink.lemmaLink?.lemma || "",
-              relatedWords: (word.motifLink?.relatedLink) ? {
-                strongCode: word.motifLink.relatedLink.id,
-                lemma: word.motifLink.relatedLink.lemma || "",
-                gloss: word.motifLink.relatedLink.gloss || "",
-              } : undefined,
+              lemma: word.motifLink.lemmaLink?.lemma || "",
               relatedStrongNums: relatedStrongNums || [],
               categories: word.motifLink?.categories || []
             }
@@ -752,7 +747,7 @@ export async function fetchPassageContentOld(studyId: string) {
           .filter("chapter", le(passageInfo.endChapter))
           .filter("verse", ge(passageInfo.startVerse))
           .filter("verse", le(passageInfo.endVerse))
-          .select(["*", "motifLink.categories", "motifLink.relatedLink.*", "motifLink.lemmaLink.lemma", "motifLink.relatedStrongCodes"])
+          .select(["*", "motifLink.categories", "motifLink.lemmaLink.lemma", "motifLink.relatedStrongCodes"])
           .sort("hebId", "asc")
           .getAll();
         
@@ -782,13 +777,6 @@ export async function fetchPassageContentOld(studyId: string) {
           hebWord.lastStropheInStanza = false;
           if (word.motifLink?.lemmaLink) {
             hebWord.lemma = word.motifLink.lemmaLink.lemma || ""
-          }
-          if (word.motifLink?.relatedLink) {
-            hebWord.relatedWords = {
-              strongCode: word.motifLink.relatedLink.id,
-              lemma: word.motifLink.relatedLink.lemma || "",
-              gloss: word.motifLink.relatedLink.gloss || "",
-            };
           }
           const relatedStrongNums = word.motifLink?.relatedStrongCodes?.map(code => parseInt(code))
                                       .filter(code => strongNumberSet.has(code) && code != word.strongNumber);

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -62,7 +62,7 @@ export type LexiconData = {
 }
 
 export type MotifData = {
-    relatedWords: LexiconData | undefined;
+    lemma: string;
     relatedStrongNums: number[] | undefined;
     categories: string[];
 }


### PR DESCRIPTION
The `relatedWords` field was originally used by the now-removed `RelatedWord` component (removed in PR #115). We later found that the extracted relationships were inaccurate, so we switched to using `motif.relatedStrongNums` and integrated related words into the `IdenticalWord` motif component.

As a result, both `motifData.relatedWords` in code and `motif.relatedLink` in db can be safely removed. This commit cleaned up `motifData.relatedWords` only, will clean up db schema after the data scripts are curated.