### PR TITLE
Fix for [Merge with Previous Line - Bug]

### DIFF
--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -39,11 +39,17 @@ const Passage = ({
 
       if (sortedWords.length === 1) {
         if (ctxStructureUpdateType === StructureUpdateType.newLine ||
-            ctxStructureUpdateType === StructureUpdateType.mergeWithPrevLine ||
             ctxStructureUpdateType === StructureUpdateType.mergeWithNextLine) {
           const line = ctxPassageProps.stanzaProps[firstSelectedWord.stanzaId]
             .strophes[firstSelectedWord.stropheId].lines[firstSelectedWord.lineId];
           lastSelectedWordId = line.words[line.words.length - 1].wordId;
+        } else if (ctxStructureUpdateType === StructureUpdateType.mergeWithPrevLine) {
+          const line = ctxPassageProps.stanzaProps[firstSelectedWord.stanzaId]
+            .strophes[firstSelectedWord.stropheId].lines[firstSelectedWord.lineId];
+          const isLineStart = line.words[0]?.wordId === selectedWordId;
+          if (isLineStart) {
+            lastSelectedWordId = line.words[line.words.length - 1].wordId;
+          }
         } else if (ctxStructureUpdateType === StructureUpdateType.newStrophe ||
                    ctxStructureUpdateType === StructureUpdateType.mergeWithPrevStrophe ||
                    ctxStructureUpdateType === StructureUpdateType.mergeWithNextStrophe) {


### PR DESCRIPTION
Fix for the following bug
```
when selecting one word in the middle of a line
then click "merge with previous line"
unexptectedly moves up entire line
correct response would take the selected word plus words before it, and move those up, rather than entire line. 
```