### PR TITLE
Add transliteration and Hebrew sound distribution tools

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,73 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CI: true
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run test:unit
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      XATA_API_KEY: ${{ secrets.XATA_API_KEY }}
+      ESV_API_KEY: ${{ secrets.ESV_API_KEY }}
+      XATA_BRANCH: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start dev server
+        run: npm run dev &
+        env:
+          NODE_ENV: development
+
+      - name: Wait for server
+        run: npx wait-on http://127.0.0.1:3000 --timeout 60000
+
+      - name: Run E2E tests
+        run: npx playwright test
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ next-env.d.ts
 
 pnpm-lock.yaml
 yarn.lock
+
+# local feature docs
+/local/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@vercel/analytics": "^1.5.0",
         "@xata.io/client": "^0.29.5",
         "clsx": "^2.1.0",
+        "dotenv": "^17.3.1",
         "drizzle-orm": "^0.45.1",
         "mitt": "^3.0.1",
         "next": "^14.2.6",
@@ -25,12 +26,12 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/node": "^20",
         "@types/pg": "^8.16.0",
         "@types/react": "^18",
         "@types/react-color": "^3.0.12",
         "@types/react-dom": "^18",
-        "@xata.io/cli": "^0.16.12",
         "autoprefixer": "^10.0.1",
         "eslint": "^8.56.0",
         "eslint-config-next": "^14.2.6",
@@ -38,20 +39,6 @@
         "react-color": "github:teamsela/react-color#master",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
-      }
-    },
-    "node_modules/@alcalzone/ansi-tokenize": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
-      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.13.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -64,31 +51,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@clerk/backend": {
@@ -220,49 +182,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@edge-runtime/format": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-3.0.1.tgz",
-      "integrity": "sha512-miO5YzjHt9zIyLyHHUqlXqH1pteK65rRrdcE9hCn6sen+vKO76JHlg9dNznQTxN+xqIPieQjGpPizC7878vT4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/ponyfill": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-3.0.0.tgz",
-      "integrity": "sha512-JQm5QjLYv/0P6/TwOjFDBfQVNPKNCRsgP8G9sWPwKzcB5bc5mt6AMtQvMloiOm+7PosvBhGB3V448eSNGd3CTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/primitives": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-5.1.1.tgz",
-      "integrity": "sha512-osrHE4ObQ3XFkvd1sGBLkheV2mcHUqJI/Bum2AWA0R3U78h9lif3xZAdl6eLD/XnW4xhsdwjPUejLusXbjvI4Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/vm": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-4.0.4.tgz",
-      "integrity": "sha512-LqPw+yaSPpCNnVZl5XoHQAySEzlnZiC9gReUuQHMh9GI03KKqwpVqWkIK1UfK116Yww7f2WZuAgnY/nhHwTsJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@edge-runtime/primitives": "5.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -384,23 +303,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@faker-js/faker": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
-      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -471,410 +373,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1184,331 +682,6 @@
         "node": ">=12.4.0"
       }
     },
-    "node_modules/@oclif/core": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.8.0.tgz",
-      "integrity": "sha512-jteNUQKgJHLHFbbz806aGZqf+RJJ7t4gwF4MYa8fCwCxQ8/klJNWc0MvaJiBebk7Mc+J39mdlsB4XraaCKznFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "ansis": "^3.17.0",
-        "clean-stack": "^3.0.1",
-        "cli-spinners": "^2.9.2",
-        "debug": "^4.4.3",
-        "ejs": "^3.1.10",
-        "get-package-type": "^0.1.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lilconfig": "^3.1.3",
-        "minimatch": "^9.0.5",
-        "semver": "^7.7.3",
-        "string-width": "^4.2.3",
-        "supports-color": "^8",
-        "tinyglobby": "^0.2.14",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-help": {
-      "version": "6.2.36",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-6.2.36.tgz",
-      "integrity": "sha512-NBQIg5hEMhvdbi4mSrdqRGl5XJ0bqTAHq6vDCCCDXUcfVtdk3ZJbSxtRVWyVvo9E28vwqu6MZyHOJylevqcHbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/core": "^4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-not-found": {
-      "version": "3.2.73",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-not-found/-/plugin-not-found-3.2.73.tgz",
-      "integrity": "sha512-2bQieTGI9XNFe9hKmXQjJmHV5rZw+yn7Rud1+C5uLEo8GaT89KZbiLTJgL35tGILahy/cB6+WAs812wjw7TK6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/prompts": "^7.10.1",
-        "@oclif/core": "^4.8.0",
-        "ansis": "^3.17.0",
-        "fast-levenshtein": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-plugins": {
-      "version": "5.4.54",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-5.4.54.tgz",
-      "integrity": "sha512-yzdukEfvvyXx31AhN+YhxLhuQdx2SrZDcRtPl5CNkuqh/uNSB2BuA3xpurdv2qotpaw/Z9InRl+Sa9bLp/4aLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@oclif/core": "^4.8.0",
-        "ansis": "^3.17.0",
-        "debug": "^4.4.0",
-        "npm": "^10.9.4",
-        "npm-package-arg": "^11.0.3",
-        "npm-run-path": "^5.3.0",
-        "object-treeify": "^4.0.1",
-        "semver": "^7.7.3",
-        "validate-npm-package-name": "^5.0.1",
-        "which": "^4.0.0",
-        "yarn": "^1.22.22"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-plugins/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-update": {
-      "version": "4.7.16",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-update/-/plugin-update-4.7.16.tgz",
-      "integrity": "sha512-/6qjxIccIv26s0BnsibRVCb5c/N46XFWOZAZPhOxG2SglQka7vsCOhEHzwIS9hqAD+WCqWRKUJnIV0rbhwjW6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/select": "^2.5.0",
-        "@oclif/core": "^4",
-        "@oclif/table": "^0.5.1",
-        "ansis": "^3.17.0",
-        "debug": "^4.4.1",
-        "filesize": "^6.1.0",
-        "got": "^13",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
-        "tar-fs": "^2.1.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/@inquirer/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/figures": "^1.0.6",
-        "@inquirer/type": "^2.0.0",
-        "@types/mute-stream": "^0.0.4",
-        "@types/node": "^22.5.5",
-        "@types/wrap-ansi": "^3.0.0",
-        "ansi-escapes": "^4.3.2",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^1.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/@inquirer/core/node_modules/@inquirer/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/@inquirer/select": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-2.5.0.tgz",
-      "integrity": "sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^9.1.0",
-        "@inquirer/figures": "^1.0.5",
-        "@inquirer/type": "^1.5.3",
-        "ansi-escapes": "^4.3.2",
-        "yoctocolors-cjs": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/@inquirer/type": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
-      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mute-stream": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/@types/node": {
-      "version": "22.19.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.5.tgz",
-      "integrity": "sha512-HfF8+mYcHPcPypui3w3mvzuIErlNOh2OAG+BCeBZCEwyiD5ls2SiCwEyT47OELtf7M3nHxBdu0FsmzdKxkN52Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/plugin-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@oclif/table": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@oclif/table/-/table-0.5.1.tgz",
-      "integrity": "sha512-k/68jl8SqJEGh+SgUYS93GK+G+EIWENuQQfJgdQBP+DP7G3evGRbe9ajdSVaL5ldMOfgZ4se4mfrEkiEVIiVvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "^18.3.12",
-        "change-case": "^5.4.4",
-        "cli-truncate": "^4.0.0",
-        "ink": "5.0.1",
-        "natural-orderby": "^3.0.2",
-        "object-hash": "^3.0.0",
-        "react": "^18.3.1",
-        "strip-ansi": "^7.1.2",
-        "wrap-ansi": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@oclif/table/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@oclif/table/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@oclif/table/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
@@ -1565,6 +738,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1578,19 +767,6 @@
       "integrity": "sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -1606,19 +782,6 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "node_modules/@tabler/icons": {
@@ -1646,26 +809,6 @@
       },
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@ts-morph/common": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
-      "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "^3.3.2",
-        "minimatch": "^9.0.4",
-        "mkdirp": "^3.0.1",
-        "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -1734,24 +877,10 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/ini": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
-      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1766,16 +895,6 @@
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
       "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
       "license": "MIT"
-    },
-    "node_modules/@types/mute-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.19.28",
@@ -1806,17 +925,6 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
-      }
-    },
-    "node_modules/@types/prompts": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
-      "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "kleur": "^3.0.3"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1889,13 +997,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -1914,13 +1015,6 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.52.0",
@@ -2479,83 +1573,6 @@
         }
       }
     },
-    "node_modules/@xata.io/cli": {
-      "version": "0.16.12",
-      "resolved": "https://registry.npmjs.org/@xata.io/cli/-/cli-0.16.12.tgz",
-      "integrity": "sha512-wyZh0cxDOISz667LLqmQXrx0i4eFZ8Dw6E9WBe7xP6l9LOthnAvw7JKxuORdz9o74WuZKBcEEDgEi+I1eRC/Ig==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@oclif/core": "^4.0.31",
-        "@oclif/plugin-help": "^6.2.16",
-        "@oclif/plugin-not-found": "^3.2.25",
-        "@oclif/plugin-plugins": "^5.4.15",
-        "@oclif/plugin-update": "^4.6.10",
-        "@types/ini": "^4.1.1",
-        "@types/prompts": "^2.4.9",
-        "@types/semver": "^7.5.8",
-        "@xata.io/client": "0.30.1",
-        "@xata.io/codegen": "0.30.1",
-        "@xata.io/importer": "1.1.6",
-        "@xata.io/pgroll": "0.7.0",
-        "ansi-regex": "^6.1.0",
-        "chalk": "^5.3.0",
-        "cosmiconfig": "^9.0.0",
-        "deepmerge": "^4.3.1",
-        "dotenv": "^16.4.5",
-        "dotenv-expand": "^11.0.6",
-        "edge-runtime": "^3.0.3",
-        "enquirer": "^2.4.1",
-        "env-editor": "^1.1.0",
-        "ini": "^5.0.0",
-        "lodash-es": "^4.17.21",
-        "node-fetch": "^3.3.2",
-        "open": "^10.1.0",
-        "prompts": "^2.4.2",
-        "relaxed-json": "^1.0.3",
-        "semver": "^7.6.3",
-        "text-table": "^0.2.0",
-        "tmp": "^0.2.3",
-        "ts-pattern": "^5.5.0",
-        "tslib": "^2.8.1",
-        "type-fest": "^4.26.1",
-        "which": "^5.0.0",
-        "zod": "^3.23.8"
-      },
-      "bin": {
-        "xata": "bin/run.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@xata.io/cli/node_modules/@xata.io/client": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.30.1.tgz",
-      "integrity": "sha512-dAzDPHmIfenVIpF39m1elmW5ngjWu2mO8ZqJBN7dmYdXr98uhPANfLdVZnc3mUNG+NH37LqY1dSO862hIo2oRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "typescript": ">=4.5"
-      }
-    },
-    "node_modules/@xata.io/cli/node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@xata.io/cli/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/@xata.io/client": {
       "version": "0.29.5",
       "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.29.5.tgz",
@@ -2563,70 +1580,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "typescript": ">=4.5"
-      }
-    },
-    "node_modules/@xata.io/codegen": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@xata.io/codegen/-/codegen-0.30.1.tgz",
-      "integrity": "sha512-sUH+iYOSZYa2AyxColpOceR86t0QpImApbe1VIK02x8kyRrB26P3zGpO2Y+1jFPfsBbG5HPPPld53PFeBXGayA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@xata.io/client": "0.30.1",
-        "case": "^1.6.3",
-        "prettier": "=2.8.8",
-        "ts-morph": "^23.0.0",
-        "typescript": "^5.6.2",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@xata.io/codegen/node_modules/@xata.io/client": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.30.1.tgz",
-      "integrity": "sha512-dAzDPHmIfenVIpF39m1elmW5ngjWu2mO8ZqJBN7dmYdXr98uhPANfLdVZnc3mUNG+NH37LqY1dSO862hIo2oRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "typescript": ">=4.5"
-      }
-    },
-    "node_modules/@xata.io/importer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-1.1.6.tgz",
-      "integrity": "sha512-veDfbHUFGtS9RKQkoso/WqjR9xNftMD88UZZgaCbXM33+GClz+D0ViE/2iADqUcKoD1PJ90eonwd9kNJqZjnSg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@faker-js/faker": "^8.4.1",
-        "@xata.io/client": "^0.30.0",
-        "any-date-parser": "^1.5.4",
-        "json5": "^2.2.3",
-        "lodash.chunk": "^4.2.0",
-        "lodash.pick": "^4.4.0",
-        "p-queue": "^8.0.1",
-        "papaparse": "^5.4.1",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@xata.io/importer/node_modules/@xata.io/client": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.30.1.tgz",
-      "integrity": "sha512-dAzDPHmIfenVIpF39m1elmW5ngjWu2mO8ZqJBN7dmYdXr98uhPANfLdVZnc3mUNG+NH37LqY1dSO862hIo2oRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "typescript": ">=4.5"
-      }
-    },
-    "node_modules/@xata.io/pgroll": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/pgroll/-/pgroll-0.7.0.tgz",
-      "integrity": "sha512-QNZsJNIyG74mi6AYXaTlVA7rdX6KmGfBnODQ37cgTnLE6Tji+GjcScXZCPCw69hAu4T56X2UqAb/+tmq4mVbhQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.5"
       }
     },
     "node_modules/acorn": {
@@ -2652,16 +1605,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2677,45 +1620,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -2743,23 +1647,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/ansis": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
-      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/any-date-parser": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/any-date-parser/-/any-date-parser-1.5.4.tgz",
-      "integrity": "sha512-S4gl9UmXNk9XXSQxp5w5harUD6aM0fepyL3dZM/B3znX57sWf792hS2UvvCFIHECfpsqfKbQ+cqWBky4AKyRIg==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -2983,30 +1870,10 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3020,34 +1887,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/async-listen": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.1.tgz",
-      "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
-    },
-    "node_modules/auto-bind": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
-      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.23",
@@ -3129,27 +1973,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
@@ -3158,16 +1981,6 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -3180,18 +1993,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -3250,47 +2051,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3300,35 +2060,6 @@
       },
       "engines": {
         "node": ">=10.16.0"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "10.2.14",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "^4.0.2",
-        "get-stream": "^6.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "keyv": "^4.5.3",
-        "mimic-response": "^4.0.0",
-        "normalize-url": "^8.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "node_modules/call-bind": {
@@ -3445,43 +2176,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/case": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
-      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
-      "dev": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3518,123 +2212,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/clean-stack": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
-      "integrity": "sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-boxes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "slice-ansi": "^5.0.0",
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3648,26 +2225,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/code-block-writer": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/code-excerpt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
-      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-to-spaces": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/color-convert": {
@@ -3702,39 +2259,12 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/convert-hrtime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
-      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/convert-to-spaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
-      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -3743,33 +2273,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/cross-spawn": {
@@ -3834,16 +2337,6 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3917,35 +2410,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3960,46 +2424,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/default-browser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-      "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -4020,19 +2444,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -4049,21 +2460,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/delayed-stream": {
@@ -4111,27 +2507,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dotenv-expand": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dotenv": "^16.4.5"
-      },
       "engines": {
         "node": ">=12"
       },
@@ -4285,59 +2664,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/edge-runtime": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-3.0.5.tgz",
-      "integrity": "sha512-E6eva65vwyF91wzCH5QtLtv4L2K8gtVuyPQ5kQ6LrYuQDB5RMzkZFQYW4OfolN0khoEaID2SCLa56pCCynbM1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@edge-runtime/format": "3.0.1",
-        "@edge-runtime/ponyfill": "3.0.0",
-        "@edge-runtime/vm": "4.0.4",
-        "async-listen": "3.0.1",
-        "mri": "1.2.0",
-        "picocolors": "1.1.1",
-        "pretty-ms": "7.0.1",
-        "signal-exit": "4.0.2",
-        "time-span": "4.0.0"
-      },
-      "bin": {
-        "edge-runtime": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/edge-runtime/node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -4351,99 +2677,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/enquirer/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/enquirer/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/env-editor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-1.3.0.tgz",
-      "integrity": "sha512-EqiD/j01PooUbeWk+etUo2TWoocjoxMfGNYpS9e47glIJ5r8WepycIki+LCbonFbPdwlqY5ETeSTAJVMih4z4w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -4639,28 +2872,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -5230,20 +3441,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -5290,13 +3487,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5339,26 +3529,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-levenshtein": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
-      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fastest-levenshtein": "^1.0.7"
-      }
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5366,30 +3536,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5403,39 +3549,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/filesize": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
-      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/fill-range": {
@@ -5538,29 +3651,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.17"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -5574,13 +3664,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -5653,19 +3736,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5690,16 +3760,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -5711,19 +3771,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -5755,31 +3802,6 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -5879,32 +3901,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/got": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^5.2.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^10.2.8",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "^2.1.2",
-        "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.10",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^3.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -6011,119 +4007,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/http2-wrapper": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
-    "node_modules/http2-wrapper/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6161,16 +4044,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6190,193 +4063,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
-      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/ink": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-5.0.1.tgz",
-      "integrity": "sha512-ae4AW/t8jlkj/6Ou21H2av0wxTk8vrGzXv+v2v7j4in+bl1M5XRMVbfNghzhBokV++FjF8RBDJvYo+ttR9YVRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.1.3",
-        "ansi-escapes": "^7.0.0",
-        "ansi-styles": "^6.2.1",
-        "auto-bind": "^5.0.1",
-        "chalk": "^5.3.0",
-        "cli-boxes": "^3.0.0",
-        "cli-cursor": "^4.0.0",
-        "cli-truncate": "^4.0.0",
-        "code-excerpt": "^4.0.0",
-        "indent-string": "^5.0.0",
-        "is-in-ci": "^0.1.0",
-        "lodash": "^4.17.21",
-        "patch-console": "^2.0.0",
-        "react-reconciler": "^0.29.0",
-        "scheduler": "^0.23.0",
-        "signal-exit": "^3.0.7",
-        "slice-ansi": "^7.1.0",
-        "stack-utils": "^2.0.6",
-        "string-width": "^7.0.0",
-        "type-fest": "^4.8.3",
-        "widest-line": "^5.0.0",
-        "wrap-ansi": "^9.0.0",
-        "ws": "^8.15.0",
-        "yoga-wasm-web": "~0.3.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "react": ">=18.0.0",
-        "react-devtools-core": "^4.19.1"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-devtools-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ink/node_modules/ansi-escapes": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ink/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ink/node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ink/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ink/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ink/node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/ink/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ink/node_modules/widest-line": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ink/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6390,16 +4076,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6419,13 +4095,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -6565,22 +4234,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6604,19 +4257,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-function": {
@@ -6649,57 +4289,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-in-ci": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
-      "integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-in-ci": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -6909,35 +4498,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -6974,24 +4540,6 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
-      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^3.2.6",
-        "filelist": "^1.0.4",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jiti": {
@@ -7038,13 +4586,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7058,19 +4599,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -7096,16 +4624,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -7190,25 +4708,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
       "dev": true,
       "license": "MIT"
     },
@@ -7231,19 +4734,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -7324,29 +4814,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -7389,55 +4856,12 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -7490,26 +4914,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/natural-orderby": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-3.0.2.tgz",
-      "integrity": "sha512-x7ZdOwBxZCEm9MM7+eQCjkrNLrW3rkBKNHVr78zbtqnMGVNlnDi6C/eUEYgxHNrcbu0ymvjzcwIL/6H1iHri9g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/next": {
       "version": "14.2.35",
@@ -7599,46 +5003,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.0.1.tgz",
@@ -7660,2747 +5024,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm": {
-      "version": "10.9.4",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.4.tgz",
-      "integrity": "sha512-OnUG836FwboQIbqtefDNlyR0gTHzIfwRfE3DuiNewBvnMnWEpB0VEXwBlFVgqpNzIgYo/MHh3d2Hel/pszapAA==",
-      "bundleDependencies": [
-        "@isaacs/string-locale-compare",
-        "@npmcli/arborist",
-        "@npmcli/config",
-        "@npmcli/fs",
-        "@npmcli/map-workspaces",
-        "@npmcli/package-json",
-        "@npmcli/promise-spawn",
-        "@npmcli/redact",
-        "@npmcli/run-script",
-        "@sigstore/tuf",
-        "abbrev",
-        "archy",
-        "cacache",
-        "chalk",
-        "ci-info",
-        "cli-columns",
-        "fastest-levenshtein",
-        "fs-minipass",
-        "glob",
-        "graceful-fs",
-        "hosted-git-info",
-        "ini",
-        "init-package-json",
-        "is-cidr",
-        "json-parse-even-better-errors",
-        "libnpmaccess",
-        "libnpmdiff",
-        "libnpmexec",
-        "libnpmfund",
-        "libnpmhook",
-        "libnpmorg",
-        "libnpmpack",
-        "libnpmpublish",
-        "libnpmsearch",
-        "libnpmteam",
-        "libnpmversion",
-        "make-fetch-happen",
-        "minimatch",
-        "minipass",
-        "minipass-pipeline",
-        "ms",
-        "node-gyp",
-        "nopt",
-        "normalize-package-data",
-        "npm-audit-report",
-        "npm-install-checks",
-        "npm-package-arg",
-        "npm-pick-manifest",
-        "npm-profile",
-        "npm-registry-fetch",
-        "npm-user-validate",
-        "p-map",
-        "pacote",
-        "parse-conflict-json",
-        "proc-log",
-        "qrcode-terminal",
-        "read",
-        "semver",
-        "spdx-expression-parse",
-        "ssri",
-        "supports-color",
-        "tar",
-        "text-table",
-        "tiny-relative-date",
-        "treeverse",
-        "validate-npm-package-name",
-        "which",
-        "write-file-atomic"
-      ],
-      "dev": true,
-      "license": "Artistic-2.0",
-      "workspaces": [
-        "docs",
-        "smoke-tests",
-        "mock-globals",
-        "mock-registry",
-        "workspaces/*"
-      ],
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/config": "^9.0.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/map-workspaces": "^4.0.2",
-        "@npmcli/package-json": "^6.2.0",
-        "@npmcli/promise-spawn": "^8.0.2",
-        "@npmcli/redact": "^3.2.2",
-        "@npmcli/run-script": "^9.1.0",
-        "@sigstore/tuf": "^3.1.1",
-        "abbrev": "^3.0.1",
-        "archy": "~1.0.0",
-        "cacache": "^19.0.1",
-        "chalk": "^5.4.1",
-        "ci-info": "^4.2.0",
-        "cli-columns": "^4.0.0",
-        "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.3",
-        "glob": "^10.4.5",
-        "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^8.1.0",
-        "ini": "^5.0.0",
-        "init-package-json": "^7.0.2",
-        "is-cidr": "^5.1.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "libnpmaccess": "^9.0.0",
-        "libnpmdiff": "^7.0.1",
-        "libnpmexec": "^9.0.1",
-        "libnpmfund": "^6.0.1",
-        "libnpmhook": "^11.0.0",
-        "libnpmorg": "^7.0.0",
-        "libnpmpack": "^8.0.1",
-        "libnpmpublish": "^10.0.1",
-        "libnpmsearch": "^8.0.0",
-        "libnpmteam": "^7.0.0",
-        "libnpmversion": "^7.0.0",
-        "make-fetch-happen": "^14.0.3",
-        "minimatch": "^9.0.5",
-        "minipass": "^7.1.1",
-        "minipass-pipeline": "^1.2.4",
-        "ms": "^2.1.2",
-        "node-gyp": "^11.2.0",
-        "nopt": "^8.1.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-audit-report": "^6.0.0",
-        "npm-install-checks": "^7.1.1",
-        "npm-package-arg": "^12.0.2",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-profile": "^11.0.1",
-        "npm-registry-fetch": "^18.0.2",
-        "npm-user-validate": "^3.0.0",
-        "p-map": "^7.0.3",
-        "pacote": "^19.0.1",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "qrcode-terminal": "^0.12.0",
-        "read": "^4.1.0",
-        "semver": "^7.7.2",
-        "spdx-expression-parse": "^4.0.0",
-        "ssri": "^12.0.0",
-        "supports-color": "^9.4.0",
-        "tar": "^6.2.1",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^6.0.1",
-        "which": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
-      },
-      "bin": {
-        "npm": "bin/npm-cli.js",
-        "npx": "bin/npx-cli.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm-package-arg": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
-      "integrity": "sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^4.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "8.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^4.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/metavuln-calculator": "^8.0.0",
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.1",
-        "@npmcli/query": "^4.0.0",
-        "@npmcli/redact": "^3.0.0",
-        "@npmcli/run-script": "^9.0.1",
-        "bin-links": "^5.0.0",
-        "cacache": "^19.0.1",
-        "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "json-stringify-nice": "^1.1.4",
-        "lru-cache": "^10.2.2",
-        "minimatch": "^9.0.4",
-        "nopt": "^8.0.0",
-        "npm-install-checks": "^7.1.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "pacote": "^19.0.0",
-        "parse-conflict-json": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "proggy": "^3.0.0",
-        "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^3.0.1",
-        "read-package-json-fast": "^4.0.0",
-        "semver": "^7.3.7",
-        "ssri": "^12.0.0",
-        "treeverse": "^3.0.0",
-        "walk-up-path": "^3.0.1"
-      },
-      "bin": {
-        "arborist": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "9.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/map-workspaces": "^4.0.1",
-        "@npmcli/package-json": "^6.0.1",
-        "ci-info": "^4.0.0",
-        "ini": "^5.0.0",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "walk-up-path": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "6.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/promise-spawn": "^8.0.0",
-        "ini": "^5.0.0",
-        "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^10.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-bundled": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "bin": {
-        "installed-package-contents": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/name-from-folder": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "glob": "^10.2.2",
-        "minimatch": "^9.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "8.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cacache": "^19.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "pacote": "^20.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
-      "version": "20.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^9.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "6.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "glob": "^10.2.2",
-        "hosted-git-info": "^8.0.0",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.5.3",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/redact": {
-      "version": "3.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/node-gyp": "^4.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "node-gyp": "^11.0.0",
-        "proc-log": "^5.0.0",
-        "which": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.1",
-        "tuf-js": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/abbrev": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/aproba": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/archy": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/bin-links": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/cacache": {
-      "version": "19.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^4.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/chownr": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/tar": {
-      "version": "7.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/cacache/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/chalk": {
-      "version": "5.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/chownr": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ci-info": {
-      "version": "4.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "ip-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/npm/node_modules/cmd-shim": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/common-ancestor-path": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cssesc": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/debug": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/diff": {
-      "version": "5.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/npm/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/npm/node_modules/env-paths": {
-      "version": "2.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/glob": {
-      "version": "10.4.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/ignore-walk": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^9.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/npm/node_modules/ini": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/init-package-json": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/package-json": "^6.0.0",
-        "npm-package-arg": "^12.0.0",
-        "promzard": "^2.0.0",
-        "read": "^4.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/ip-address": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/npm/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "cidr-regex": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/isexe": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/json-stringify-nice": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/jsonparse": {
-      "version": "1.3.1",
-      "dev": true,
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/just-diff": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "9.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "binary-extensions": "^2.3.0",
-        "diff": "^5.1.0",
-        "minimatch": "^9.0.4",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0",
-        "tar": "^6.2.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "9.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "ci-info": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0",
-        "proc-log": "^5.0.0",
-        "read": "^4.0.0",
-        "read-package-json-fast": "^4.0.0",
-        "semver": "^7.3.7",
-        "walk-up-path": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^8.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmhook": {
-      "version": "11.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "8.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^8.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "npm-package-arg": "^12.0.0",
-        "pacote": "^19.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "10.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ci-info": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
-        "npm-package-arg": "^12.0.0",
-        "npm-registry-fetch": "^18.0.1",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.7",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "8.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmteam": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^18.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmversion": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.1",
-        "@npmcli/run-script": "^9.0.1",
-        "json-parse-even-better-errors": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/minipass": {
-      "version": "7.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minizlib": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/npm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/mute-stream": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp": {
-      "version": "11.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "tar": "^7.4.3",
-        "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
-      "version": "7.4.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^3.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "7.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "12.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^8.0.0",
-        "proc-log": "^5.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "9.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^7.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "10.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^7.1.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "npm-package-arg": "^12.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "11.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "18.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/redact": "^3.0.0",
-        "jsonparse": "^1.3.1",
-        "make-fetch-happen": "^14.0.0",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minizlib": "^3.0.1",
-        "npm-package-arg": "^12.0.0",
-        "proc-log": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/p-map": {
-      "version": "7.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/npm/node_modules/pacote": {
-      "version": "19.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/git": "^6.0.0",
-        "@npmcli/installed-package-contents": "^3.0.0",
-        "@npmcli/package-json": "^6.0.0",
-        "@npmcli/promise-spawn": "^8.0.0",
-        "@npmcli/run-script": "^9.0.0",
-        "cacache": "^19.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^12.0.0",
-        "npm-packlist": "^9.0.0",
-        "npm-pick-manifest": "^10.0.0",
-        "npm-registry-fetch": "^18.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "sigstore": "^3.0.0",
-        "ssri": "^12.0.0",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "pacote": "bin/index.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "just-diff": "^6.0.0",
-        "just-diff-apply": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/path-key": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/proc-log": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/proggy": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/promise-all-reject-late": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/promzard": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "read": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/npm/node_modules/read": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "json-parse-even-better-errors": "^4.0.0",
-        "npm-normalize-package-bin": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/npm/node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/npm/node_modules/semver": {
-      "version": "7.7.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "@sigstore/sign": "^3.1.0",
-        "@sigstore/tuf": "^3.1.0",
-        "@sigstore/verify": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.4.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "make-fetch-happen": "^14.0.2",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/socks": {
-      "version": "2.8.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/npm/node_modules/ssri": {
-      "version": "12.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "9.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/tar": {
-      "version": "6.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minizlib": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/text-table": {
-      "version": "0.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/tiny-relative-date": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/npm/node_modules/treeverse": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/models": "3.0.1",
-        "debug": "^4.3.6",
-        "make-fetch-happen": "^14.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/walk-up-path": {
-      "version": "3.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/which": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/which/node_modules/isexe": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10441,16 +5064,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-treeify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-4.0.1.tgz",
-      "integrity": "sha512-Y6tg5rHfsefSkfKujv2SwHulInROy/rCL5F4w0QOWxut8AnxYxf0YmNhTh95Zfyxpsudo66uqkux0ACFnyMSgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/object.assign": {
@@ -10553,41 +5166,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10631,16 +5209,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10673,77 +5241,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-queue": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
-      "integrity": "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
-      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/papaparse": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
-      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10756,52 +5253,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse-ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/patch-console": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
-      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -10979,6 +5430,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -11196,62 +5693,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/pretty-ms": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/proc-log": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
-      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -11261,54 +5702,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -11432,23 +5825,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/react-reconciler": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
-      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "node_modules/reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
@@ -11466,21 +5842,6 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -11539,101 +5900,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/relaxed-json": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/relaxed-json/-/relaxed-json-1.0.3.tgz",
-      "integrity": "sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "commander": "^2.6.0"
-      },
-      "bin": {
-        "rjson": "bin/rjson.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/relaxed-json/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/relaxed-json/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/relaxed-json/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/relaxed-json/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/relaxed-json/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/relaxed-json/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/relaxed-json/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -11654,13 +5920,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -11680,46 +5939,6 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
-    },
-    "node_modules/responselike": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -11794,19 +6013,6 @@
         "node": "*"
       }
     },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11850,27 +6056,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -11905,13 +6090,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -12096,41 +6274,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/slice-ansi": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.0.0",
-        "is-fullwidth-code-point": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -12167,47 +6310,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -12233,29 +6335,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -12276,16 +6355,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -12629,22 +6698,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -12718,36 +6771,6 @@
         "tailwindcss": ">=3"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -12774,22 +6797,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/time-span": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/time-span/-/time-span-4.0.0.tgz",
-      "integrity": "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "convert-hrtime": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinycolor2": {
@@ -12842,16 +6849,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/to-no-case": {
@@ -12909,24 +6906,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
-    "node_modules/ts-morph": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
-      "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ts-morph/common": "~0.24.0",
-        "code-block-writer": "^13.0.1"
-      }
-    },
-    "node_modules/ts-pattern": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
-      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -12970,19 +6949,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -13204,26 +7170,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/validate-npm-package-name": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
-      "integrity": "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webcrypto-core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
@@ -13242,22 +7188,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
@@ -13348,19 +7278,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -13369,31 +7286,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi-cjs": {
@@ -13454,105 +7346,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wsl-utils/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -13561,21 +7360,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
-      }
-    },
-    "node_modules/yarn": {
-      "version": "1.22.22",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.22.tgz",
-      "integrity": "sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "yarn": "bin/yarn.js",
-        "yarnpkg": "bin/yarn.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/yocto-queue": {
@@ -13591,26 +7375,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoga-wasm-web": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
-      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -13618,16 +7382,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "postcss": "^8.4.34",
         "react-color": "github:teamsela/react-color#master",
         "tailwindcss": "^3.3.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -214,6 +215,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -754,6 +1197,356 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -832,6 +1625,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -852,6 +1656,20 @@
         "@types/keygrip": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.14",
@@ -1573,6 +2391,121 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xata.io/client": {
       "version": "0.29.5",
       "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.29.5.tgz",
@@ -1870,6 +2803,16 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2062,6 +3005,16 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2175,6 +3128,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2408,6 +3388,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2793,6 +3783,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2849,6 +3846,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -3477,6 +4516,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3485,6 +4534,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4727,6 +5786,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -4742,6 +5808,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
@@ -5307,6 +6383,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pg": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
@@ -5468,6 +6561,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6013,6 +7107,51 @@
         "node": "*"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6261,6 +7400,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6332,6 +7478,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6644,6 +7804,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -6799,10 +7979,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6849,6 +8043,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-no-case": {
@@ -7170,6 +8394,221 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/webcrypto-core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
@@ -7276,6 +8715,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.5",
@@ -14,6 +15,7 @@
     "@vercel/analytics": "^1.5.0",
     "@xata.io/client": "^0.29.5",
     "clsx": "^2.1.0",
+    "dotenv": "^17.3.1",
     "drizzle-orm": "^0.45.1",
     "mitt": "^3.0.1",
     "next": "^14.2.6",
@@ -26,12 +28,12 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^20",
     "@types/pg": "^8.16.0",
     "@types/react": "^18",
     "@types/react-color": "^3.0.12",
     "@types/react-dom": "^18",
-    "@xata.io/cli": "^0.16.12",
     "autoprefixer": "^10.0.1",
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.2.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "test": "vitest run && playwright test"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.5",
@@ -40,6 +43,7 @@
     "postcss": "^8.4.34",
     "react-color": "github:teamsela/react-color#master",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,13 +2,20 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  testMatch: "*.spec.ts",
   timeout: 120_000,
   expect: {
     timeout: 10_000,
   },
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"]]
+    : [["html", { open: "on-failure" }]],
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
     trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
-  timeout: 60_000,
+  timeout: 120_000,
   expect: {
     timeout: 10_000,
   },

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -95,21 +95,21 @@ const LanguageSwitcher = () => {
             className={`rounded-tl-[5px] rounded-bl-[5px] border-r-2 border-r-[#D9D9D9] ${base} ${ctxLanguageMode === LanguageMode.English ? active : ""}`}
           >
             A
-            {ctxLanguageMode === LanguageMode.English && <span onClick={toggleDropdown}><Chevron /></span>}
+            <span onClick={toggleDropdown}><Chevron /></span>
           </span>
           <span
             onClick={() => handleSwitcherClick(LanguageMode.Parallel)}
             className={`${base} ${ctxLanguageMode === LanguageMode.Parallel ? active : ""}`}
           >
             Aא
-            {ctxLanguageMode === LanguageMode.Parallel && <span onClick={toggleDropdown}><Chevron /></span>}
+            <span onClick={toggleDropdown}><Chevron /></span>
           </span>
           <span
             onClick={() => handleSwitcherClick(LanguageMode.Hebrew)}
             className={`rounded-tr-[5px] rounded-br-[5px] border-l-2 border-l-[#D9D9D9] ${base} ${ctxLanguageMode === LanguageMode.Hebrew ? active : ""}`}
           >
             א
-            {ctxLanguageMode === LanguageMode.Hebrew && <span onClick={toggleDropdown}><Chevron /></span>}
+            <span onClick={toggleDropdown}><Chevron /></span>
           </span>
         </div>
       </label>

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -12,7 +12,6 @@ const getDropdownOptions = (mode: LanguageMode): DropdownOption[] => {
     case LanguageMode.Parallel:
       return [
         { value: NonEnglishDisplayMode.Hebrew, label: "English Gloss / Hebrew OHB" },
-        { value: NonEnglishDisplayMode.Transliteration, label: "English / Transliteration" },
         { value: NonEnglishDisplayMode.HebrewTransliteration, label: "English Gloss / Hebrew Transliteration" },
       ];
     case LanguageMode.Hebrew:

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -1,7 +1,12 @@
-import { useContext } from 'react';
+import { useContext, useState, useRef, useEffect } from 'react';
 import { FormatContext } from '../index';
 import { LanguageMode, NonEnglishDisplayMode } from "@/lib/types";
 import { updateMetadataInDb } from '@/lib/actions';
+
+const displayModeOptions = [
+  { value: NonEnglishDisplayMode.Hebrew, label: "English Gloss / Hebrew OHB" },
+  { value: NonEnglishDisplayMode.HebrewTransliteration, label: "English Gloss / Hebrew Transliteration" },
+];
 
 const LanguageSwitcher = () => {
   const {
@@ -14,70 +19,108 @@ const LanguageSwitcher = () => {
     ctxInViewMode,
   } = useContext(FormatContext);
 
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
   const handleSwitcherClick = (mode: LanguageMode) => {
-    if (mode != ctxLanguageMode)
-    {
+    if (mode !== ctxLanguageMode) {
       ctxStudyMetadata.lang = mode;
       if (!ctxInViewMode) {
         updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
       }
       ctxSetLanguageMode(mode);
+      setDropdownOpen(false);
     }
-  }
-
-  const handleDisplayModeChange = (mode: NonEnglishDisplayMode) => {
-    if (mode === ctxNonEnglishDisplayMode) {
-      return;
-    }
-
-    ctxStudyMetadata.nonEnglishDisplayMode = mode;
-    if (!ctxInViewMode) {
-      updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
-    }
-    ctxSetNonEnglishDisplayMode(mode);
   };
 
-  const buttonBaseStyle = 'px-[24px] py-[6px]';
-  const buttonSelectedStyle = 'bg-[#FFFFFF] font-bold'
-  const shouldShowDisplayDropdown = ctxLanguageMode !== LanguageMode.English;
+  const handleDisplayModeChange = (mode: NonEnglishDisplayMode) => {
+    if (mode !== ctxNonEnglishDisplayMode) {
+      ctxStudyMetadata.nonEnglishDisplayMode = mode;
+      if (!ctxInViewMode) {
+        updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
+      }
+      ctxSetNonEnglishDisplayMode(mode);
+    }
+    setDropdownOpen(false);
+  };
+
+  const toggleDropdown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDropdownOpen((prev) => !prev);
+  };
+
+  const buttonBaseStyle = "flex items-center gap-[2px] px-[16px] py-[6px] cursor-pointer";
+  const buttonSelectedStyle = "bg-[#FFFFFF] font-bold";
+  const chevron = (
+    <svg width="10" height="6" viewBox="0 0 10 6" fill="currentColor" className="ml-[2px] opacity-60">
+      <path d="M1 1l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+
+  const showDropdown = ctxLanguageMode !== LanguageMode.English;
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="relative" ref={dropdownRef}>
       <label
         htmlFor="toggleLang"
         className="flex cursor-pointer select-none items-center ml-2"
       >
-        <div className="relative">
-
-          <div className='flex flex-row rounded-[5px] bg-[#F2F2F2] border-[2px] border-[#D9D9D9] top-0 w-full h-full place-content-around items-center'>
-            <span onClick={() => { handleSwitcherClick(LanguageMode.English) }} className={`rounded-tl-[5px] rounded-bl-[5px] border-r-2 border-r-[#D9D9D9] ${buttonBaseStyle} ${ctxLanguageMode == LanguageMode.English && buttonSelectedStyle}`}>
-              A
-            </span>
-            <span onClick={() => { handleSwitcherClick(LanguageMode.Parallel) }} className={`${buttonBaseStyle} ${ctxLanguageMode == LanguageMode.Parallel && buttonSelectedStyle}`}>
-              Aא
-            </span>
-            <span onClick={() => { handleSwitcherClick(LanguageMode.Hebrew) }} className={`rounded-tr-[5px] rounded-br-[5px] border-l-2 border-l-[#D9D9D9] ${buttonBaseStyle} ${ctxLanguageMode == LanguageMode.Hebrew && buttonSelectedStyle}`}>
-              א
-            </span>
-          </div>
-
+        <div className="flex flex-row rounded-[5px] bg-[#F2F2F2] border-[2px] border-[#D9D9D9] place-content-around items-center">
+          <span
+            onClick={() => handleSwitcherClick(LanguageMode.English)}
+            className={`rounded-tl-[5px] rounded-bl-[5px] border-r-2 border-r-[#D9D9D9] ${buttonBaseStyle} ${ctxLanguageMode === LanguageMode.English ? buttonSelectedStyle : ""}`}
+          >
+            A
+          </span>
+          <span
+            onClick={() => handleSwitcherClick(LanguageMode.Parallel)}
+            className={`${buttonBaseStyle} ${ctxLanguageMode === LanguageMode.Parallel ? buttonSelectedStyle : ""}`}
+          >
+            Aא
+            {ctxLanguageMode === LanguageMode.Parallel && (
+              <span onClick={toggleDropdown} className="ml-[2px]">{chevron}</span>
+            )}
+          </span>
+          <span
+            onClick={() => handleSwitcherClick(LanguageMode.Hebrew)}
+            className={`rounded-tr-[5px] rounded-br-[5px] border-l-2 border-l-[#D9D9D9] ${buttonBaseStyle} ${ctxLanguageMode === LanguageMode.Hebrew ? buttonSelectedStyle : ""}`}
+          >
+            א
+            {ctxLanguageMode === LanguageMode.Hebrew && (
+              <span onClick={toggleDropdown} className="ml-[2px]">{chevron}</span>
+            )}
+          </span>
         </div>
       </label>
-      {shouldShowDisplayDropdown && (
-        <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
-          <span>Display</span>
-          <select
-            value={ctxNonEnglishDisplayMode}
-            onChange={(event) =>
-              handleDisplayModeChange(Number(event.target.value) as NonEnglishDisplayMode)
-            }
-            className="rounded-md border border-[#D9D9D9] bg-white px-3 py-1.5 text-sm text-slate-700 outline-none transition focus:border-primary"
-          >
-            <option value={NonEnglishDisplayMode.Hebrew}>English Gloss / Hebrew OHB</option>
-            <option value={NonEnglishDisplayMode.Transliteration}>English / Transliteration</option>
-            <option value={NonEnglishDisplayMode.HebrewTransliteration}>English Gloss / Hebrew Transliteration</option>
-          </select>
-        </label>
+
+      {showDropdown && dropdownOpen && (
+        <div className="absolute right-0 top-full mt-1 z-50 min-w-[280px] rounded-md border border-[#D9D9D9] bg-white py-1 shadow-lg">
+          {displayModeOptions.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => handleDisplayModeChange(opt.value)}
+              className={`block w-full px-4 py-2 text-left text-sm hover:bg-[#F2F2F2] ${
+                ctxNonEnglishDisplayMode === opt.value
+                  ? "font-semibold text-primary"
+                  : "text-slate-700"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -1,25 +1,48 @@
 import { useContext } from 'react';
 import { FormatContext } from '../index';
-import { LanguageMode } from "@/lib/types";
+import { LanguageMode, NonEnglishDisplayMode } from "@/lib/types";
 import { updateMetadataInDb } from '@/lib/actions';
 
 const LanguageSwitcher = () => {
-  const { ctxStudyId, ctxLanguageMode, ctxSetLanguageMode, ctxStudyMetadata } = useContext(FormatContext);
+  const {
+    ctxStudyId,
+    ctxLanguageMode,
+    ctxSetLanguageMode,
+    ctxStudyMetadata,
+    ctxNonEnglishDisplayMode,
+    ctxSetNonEnglishDisplayMode,
+    ctxInViewMode,
+  } = useContext(FormatContext);
 
   const handleSwitcherClick = (mode: LanguageMode) => {
     if (mode != ctxLanguageMode)
     {
       ctxStudyMetadata.lang = mode;
-      updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
+      if (!ctxInViewMode) {
+        updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
+      }
       ctxSetLanguageMode(mode);
     }
   }
 
+  const handleDisplayModeChange = (mode: NonEnglishDisplayMode) => {
+    if (mode === ctxNonEnglishDisplayMode) {
+      return;
+    }
+
+    ctxStudyMetadata.nonEnglishDisplayMode = mode;
+    if (!ctxInViewMode) {
+      updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
+    }
+    ctxSetNonEnglishDisplayMode(mode);
+  };
+
   const buttonBaseStyle = 'px-[24px] py-[6px]';
   const buttonSelectedStyle = 'bg-[#FFFFFF] font-bold'
+  const shouldShowDisplayDropdown = ctxLanguageMode !== LanguageMode.English;
 
   return (
-    <div>
+    <div className="flex items-center gap-3">
       <label
         htmlFor="toggleLang"
         className="flex cursor-pointer select-none items-center ml-2"
@@ -40,6 +63,21 @@ const LanguageSwitcher = () => {
 
         </div>
       </label>
+      {shouldShowDisplayDropdown && (
+        <label className="flex items-center gap-2 text-sm font-medium text-slate-700">
+          <span>Display</span>
+          <select
+            value={ctxNonEnglishDisplayMode}
+            onChange={(event) =>
+              handleDisplayModeChange(Number(event.target.value) as NonEnglishDisplayMode)
+            }
+            className="rounded-md border border-[#D9D9D9] bg-white px-3 py-1.5 text-sm text-slate-700 outline-none transition focus:border-primary"
+          >
+            <option value={NonEnglishDisplayMode.Hebrew}>Hebrew OHB</option>
+            <option value={NonEnglishDisplayMode.Transliteration}>Transliteration</option>
+          </select>
+        </label>
+      )}
     </div>
   );
 };

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -12,6 +12,7 @@ const getDropdownOptions = (mode: LanguageMode): DropdownOption[] => {
     case LanguageMode.Parallel:
       return [
         { value: NonEnglishDisplayMode.Hebrew, label: "English Gloss / Hebrew OHB" },
+        { value: NonEnglishDisplayMode.Transliteration, label: "English / Transliteration" },
         { value: NonEnglishDisplayMode.HebrewTransliteration, label: "English Gloss / Hebrew Transliteration" },
       ];
     case LanguageMode.Hebrew:

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -121,11 +121,7 @@ const LanguageSwitcher = () => {
               key={opt.label}
               type="button"
               onClick={() => handleOptionClick(opt)}
-              className={`block w-full px-4 py-2 text-left text-sm hover:bg-[#F2F2F2] ${
-                opt.value !== undefined && ctxNonEnglishDisplayMode === opt.value
-                  ? "font-semibold text-primary"
-                  : "text-slate-700"
-              }`}
+              className="block w-full px-4 py-2 text-left text-sm text-slate-700 hover:bg-[#F2F2F2]"
             >
               {opt.label}
             </button>

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -73,8 +73,9 @@ const LanguageSwitcher = () => {
             }
             className="rounded-md border border-[#D9D9D9] bg-white px-3 py-1.5 text-sm text-slate-700 outline-none transition focus:border-primary"
           >
-            <option value={NonEnglishDisplayMode.Hebrew}>Hebrew OHB</option>
-            <option value={NonEnglishDisplayMode.Transliteration}>Transliteration</option>
+            <option value={NonEnglishDisplayMode.Hebrew}>English Gloss / Hebrew OHB</option>
+            <option value={NonEnglishDisplayMode.Transliteration}>English / Transliteration</option>
+            <option value={NonEnglishDisplayMode.HebrewTransliteration}>English Gloss / Hebrew Transliteration</option>
           </select>
         </label>
       )}

--- a/src/components/StudyPane/Header/LanguageSwitcher.tsx
+++ b/src/components/StudyPane/Header/LanguageSwitcher.tsx
@@ -3,10 +3,30 @@ import { FormatContext } from '../index';
 import { LanguageMode, NonEnglishDisplayMode } from "@/lib/types";
 import { updateMetadataInDb } from '@/lib/actions';
 
-const displayModeOptions = [
-  { value: NonEnglishDisplayMode.Hebrew, label: "English Gloss / Hebrew OHB" },
-  { value: NonEnglishDisplayMode.HebrewTransliteration, label: "English Gloss / Hebrew Transliteration" },
-];
+type DropdownOption = { label: string; value?: NonEnglishDisplayMode };
+
+const getDropdownOptions = (mode: LanguageMode): DropdownOption[] => {
+  switch (mode) {
+    case LanguageMode.English:
+      return [{ label: "English Gloss" }];
+    case LanguageMode.Parallel:
+      return [
+        { value: NonEnglishDisplayMode.Hebrew, label: "English Gloss / Hebrew OHB" },
+        { value: NonEnglishDisplayMode.HebrewTransliteration, label: "English Gloss / Hebrew Transliteration" },
+      ];
+    case LanguageMode.Hebrew:
+      return [
+        { value: NonEnglishDisplayMode.Hebrew, label: "Hebrew OHB" },
+        { value: NonEnglishDisplayMode.HebrewTransliteration, label: "Transliteration" },
+      ];
+  }
+};
+
+const Chevron = () => (
+  <svg width="10" height="6" viewBox="0 0 10 6" className="ml-[2px] opacity-60">
+    <path d="M1 1l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
 
 const LanguageSwitcher = () => {
   const {
@@ -20,12 +40,11 @@ const LanguageSwitcher = () => {
   } = useContext(FormatContext);
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
-  // Close dropdown on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
         setDropdownOpen(false);
       }
     };
@@ -44,13 +63,13 @@ const LanguageSwitcher = () => {
     }
   };
 
-  const handleDisplayModeChange = (mode: NonEnglishDisplayMode) => {
-    if (mode !== ctxNonEnglishDisplayMode) {
-      ctxStudyMetadata.nonEnglishDisplayMode = mode;
+  const handleOptionClick = (opt: DropdownOption) => {
+    if (opt.value !== undefined && opt.value !== ctxNonEnglishDisplayMode) {
+      ctxStudyMetadata.nonEnglishDisplayMode = opt.value;
       if (!ctxInViewMode) {
         updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
       }
-      ctxSetNonEnglishDisplayMode(mode);
+      ctxSetNonEnglishDisplayMode(opt.value);
     }
     setDropdownOpen(false);
   };
@@ -60,18 +79,12 @@ const LanguageSwitcher = () => {
     setDropdownOpen((prev) => !prev);
   };
 
-  const buttonBaseStyle = "flex items-center gap-[2px] px-[16px] py-[6px] cursor-pointer";
-  const buttonSelectedStyle = "bg-[#FFFFFF] font-bold";
-  const chevron = (
-    <svg width="10" height="6" viewBox="0 0 10 6" fill="currentColor" className="ml-[2px] opacity-60">
-      <path d="M1 1l4 4 4-4" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>
-  );
-
-  const showDropdown = ctxLanguageMode !== LanguageMode.English;
+  const base = "flex items-center gap-[2px] px-[16px] py-[6px] cursor-pointer";
+  const active = "bg-[#FFFFFF] font-bold";
+  const options = getDropdownOptions(ctxLanguageMode);
 
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div className="relative" ref={ref}>
       <label
         htmlFor="toggleLang"
         className="flex cursor-pointer select-none items-center ml-2"
@@ -79,40 +92,37 @@ const LanguageSwitcher = () => {
         <div className="flex flex-row rounded-[5px] bg-[#F2F2F2] border-[2px] border-[#D9D9D9] place-content-around items-center">
           <span
             onClick={() => handleSwitcherClick(LanguageMode.English)}
-            className={`rounded-tl-[5px] rounded-bl-[5px] border-r-2 border-r-[#D9D9D9] ${buttonBaseStyle} ${ctxLanguageMode === LanguageMode.English ? buttonSelectedStyle : ""}`}
+            className={`rounded-tl-[5px] rounded-bl-[5px] border-r-2 border-r-[#D9D9D9] ${base} ${ctxLanguageMode === LanguageMode.English ? active : ""}`}
           >
             A
+            {ctxLanguageMode === LanguageMode.English && <span onClick={toggleDropdown}><Chevron /></span>}
           </span>
           <span
             onClick={() => handleSwitcherClick(LanguageMode.Parallel)}
-            className={`${buttonBaseStyle} ${ctxLanguageMode === LanguageMode.Parallel ? buttonSelectedStyle : ""}`}
+            className={`${base} ${ctxLanguageMode === LanguageMode.Parallel ? active : ""}`}
           >
             Aא
-            {ctxLanguageMode === LanguageMode.Parallel && (
-              <span onClick={toggleDropdown} className="ml-[2px]">{chevron}</span>
-            )}
+            {ctxLanguageMode === LanguageMode.Parallel && <span onClick={toggleDropdown}><Chevron /></span>}
           </span>
           <span
             onClick={() => handleSwitcherClick(LanguageMode.Hebrew)}
-            className={`rounded-tr-[5px] rounded-br-[5px] border-l-2 border-l-[#D9D9D9] ${buttonBaseStyle} ${ctxLanguageMode === LanguageMode.Hebrew ? buttonSelectedStyle : ""}`}
+            className={`rounded-tr-[5px] rounded-br-[5px] border-l-2 border-l-[#D9D9D9] ${base} ${ctxLanguageMode === LanguageMode.Hebrew ? active : ""}`}
           >
             א
-            {ctxLanguageMode === LanguageMode.Hebrew && (
-              <span onClick={toggleDropdown} className="ml-[2px]">{chevron}</span>
-            )}
+            {ctxLanguageMode === LanguageMode.Hebrew && <span onClick={toggleDropdown}><Chevron /></span>}
           </span>
         </div>
       </label>
 
-      {showDropdown && dropdownOpen && (
+      {dropdownOpen && (
         <div className="absolute right-0 top-full mt-1 z-50 min-w-[280px] rounded-md border border-[#D9D9D9] bg-white py-1 shadow-lg">
-          {displayModeOptions.map((opt) => (
+          {options.map((opt) => (
             <button
-              key={opt.value}
+              key={opt.label}
               type="button"
-              onClick={() => handleDisplayModeChange(opt.value)}
+              onClick={() => handleOptionClick(opt)}
               className={`block w-full px-4 py-2 text-left text-sm hover:bg-[#F2F2F2] ${
-                ctxNonEnglishDisplayMode === opt.value
+                opt.value !== undefined && ctxNonEnglishDisplayMode === opt.value
                   ? "font-semibold text-primary"
                   : "text-slate-700"
               }`}

--- a/src/components/StudyPane/Header/Tabs.tsx
+++ b/src/components/StudyPane/Header/Tabs.tsx
@@ -59,8 +59,11 @@ export const Tabs = ({
         Syntax
       </button>
       <button
-        className="inline-flex rounded-r-full border border-primary font-medium text-meta-9 dark:border-strokedark dark:text-white dark:hover:border-primary sm:px-4 sm:py-[6px]"
-        disabled={true}
+        className={`inline-flex rounded-r-full border border-primary font-medium text-black dark:border-strokedark hover:border-primary hover:bg-primary hover:text-white dark:text-white dark:hover:border-primary sm:px-4 sm:py-[6px]
+          ${
+            infoPaneAction === InfoPaneActionType.sounds ? activeClasses : inactiveClasses
+          }`}
+        onClick={() => handleClick(InfoPaneActionType.sounds)}
       >
         Sounds
       </button>

--- a/src/components/StudyPane/InfoPane/Sounds.tsx
+++ b/src/components/StudyPane/InfoPane/Sounds.tsx
@@ -45,18 +45,18 @@ const DistributionChip = ({
   const chipText = isHighlighted ? (text ?? "#525252") : "#525252";
 
   return (
-    <div className="my-1 flex">
+    <div className="flex justify-center">
       <button
         type="button"
         onClick={onClick}
-        className={`wordBlock mx-1 flex rounded border ${statusClassName}`}
+        className={`wordBlock flex w-full rounded border ${statusClassName}`}
         style={{
           background: chipFill,
           border: `2px solid ${chipBorder}`,
           color: chipText,
         }}
       >
-        <span className="flex select-none items-center justify-center gap-2 px-3 py-1 text-center text-base leading-none hover:opacity-80">
+        <span className="flex w-full select-none items-center justify-center gap-2 px-2 py-1.5 text-center text-base leading-none hover:opacity-80">
           <span>{label}</span>
           <span className="flex h-6.5 min-w-6.5 items-center justify-center rounded-full bg-[#EFEFEF] px-1 text-sm text-black">
             {count}
@@ -240,7 +240,7 @@ const Sounds = () => {
 
           {openSection === "sound-distribution" && (
             <div className="space-y-4 p-4">
-              <div className="flex flex-wrap">
+              <div className="grid grid-cols-4 gap-1">
                 {SOUND_CHIPS.map((chip) => (
                   <DistributionChip
                     key={chip.id}
@@ -280,7 +280,7 @@ const Sounds = () => {
 
           {openSection === "letter-distribution" && (
             <div className="space-y-4 p-4">
-              <div className="flex flex-wrap">
+              <div className="grid grid-cols-4 gap-1">
                 {LETTER_CHIP_GROUPS.map((group) => {
                   const groupCount = group.memberIds.reduce(
                     (sum, id) => sum + (letterCounts.get(id) || 0),

--- a/src/components/StudyPane/InfoPane/Sounds.tsx
+++ b/src/components/StudyPane/InfoPane/Sounds.tsx
@@ -5,6 +5,7 @@ import AccordionToggleIcon from "./common/AccordionToggleIcon";
 import {
   countLetterOccurrences,
   countSoundOccurrences,
+  LETTER_CHIP_GROUPS,
   LETTER_CHIPS,
   SOUND_CHIPS,
 } from "@/lib/hebrewHighlights";
@@ -101,6 +102,8 @@ const Sounds = () => {
   } = useContext(FormatContext);
   const [openSection, setOpenSection] = useState<SoundsSectionId>("sound-distribution");
 
+  const [showTooltip, setShowTooltip] = useState(false);
+
   const toggleSection = (sectionId: SoundsSectionId) => {
     setOpenSection((prev) => (prev === sectionId ? prev : sectionId));
   };
@@ -165,11 +168,12 @@ const Sounds = () => {
     );
   };
 
-  const toggleLetterChip = (chipId: string) => {
+  const toggleLetterChip = (memberIds: string[]) => {
+    const allSelected = memberIds.every((id) => ctxSelectedLetterChipIds.includes(id));
     ctxSetSelectedLetterChipIds(
-      ctxSelectedLetterChipIds.includes(chipId)
-        ? ctxSelectedLetterChipIds.filter((id) => id !== chipId)
-        : [...ctxSelectedLetterChipIds, chipId],
+      allSelected
+        ? ctxSelectedLetterChipIds.filter((id) => !memberIds.includes(id))
+        : [...ctxSelectedLetterChipIds.filter((id) => !memberIds.includes(id)), ...memberIds],
     );
   };
 
@@ -198,7 +202,7 @@ const Sounds = () => {
   };
 
   const soundTooltip =
-    "Different Hebrew letters can produce similar sounds. This tool highlights sound patterns by how words are heard, not just how they are written. Sound highlights only appear in transliteration and Hebrew display modes.";
+    "Different Hebrew letters can produce similar sounds. This tool helps you detect sound patterns and rhymes based on how words are heard, not how they are written. The highlighted Hebrew sound patterns are only visible in the English transliteration and Hebrew text, not in the default English display.";
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
@@ -214,10 +218,18 @@ const Sounds = () => {
               Hebrew Sound Distribution
             </span>
             <span
-              className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-xs text-slate-500"
+              className="relative ml-1 inline-flex h-5 w-5 cursor-help items-center justify-center rounded-full border border-slate-300 text-xs text-slate-500"
+              onClick={(e) => { e.stopPropagation(); setShowTooltip((v) => !v); }}
+              onMouseEnter={() => setShowTooltip(true)}
+              onMouseLeave={() => setShowTooltip(false)}
               title={soundTooltip}
             >
               i
+              {showTooltip && (
+                <div className="absolute left-1/2 top-full z-50 mt-2 w-72 -translate-x-1/2 rounded-lg border border-slate-200 bg-white p-3 text-xs leading-relaxed text-slate-700 shadow-lg dark:border-strokedark dark:bg-boxdark dark:text-bodydark">
+                  {soundTooltip}
+                </div>
+              )}
             </span>
           </button>
 
@@ -257,26 +269,37 @@ const Sounds = () => {
           >
             <AccordionToggleIcon isOpen={openSection === "letter-distribution"} />
             <span className={openSection === "letter-distribution" ? "text-primary" : "text-black dark:text-white"}>
-              Hebrew Letter Distribution
+              Hebrew Letters Distribution
             </span>
           </button>
 
           {openSection === "letter-distribution" && (
             <div className="space-y-4 p-4">
               <div className="flex flex-wrap">
-                {LETTER_CHIPS.map((chip) => (
-                  <DistributionChip
-                    key={chip.id}
-                    label={chip.label}
-                    count={letterCounts.get(chip.id) || 0}
-                    fill={chip.palette.fill}
-                    border={chip.palette.border}
-                    text={chip.palette.text}
-                    isSelected={ctxSelectedLetterChipIds.includes(chip.id)}
-                    isHighlighted={ctxLetterHighlightEnabled && ctxSelectedLetterChipIds.includes(chip.id)}
-                    onClick={() => toggleLetterChip(chip.id)}
-                  />
-                ))}
+                {LETTER_CHIP_GROUPS.map((group) => {
+                  const groupCount = group.memberIds.reduce(
+                    (sum, id) => sum + (letterCounts.get(id) || 0),
+                    0,
+                  );
+                  const isSelected = group.memberIds.every((id) =>
+                    ctxSelectedLetterChipIds.includes(id),
+                  );
+                  const isHighlighted = ctxLetterHighlightEnabled && isSelected;
+
+                  return (
+                    <DistributionChip
+                      key={group.id}
+                      label={group.label}
+                      count={groupCount}
+                      fill={group.palette.fill}
+                      border={group.palette.border}
+                      text={group.palette.text}
+                      isSelected={isSelected}
+                      isHighlighted={isHighlighted}
+                      onClick={() => toggleLetterChip(group.memberIds)}
+                    />
+                  );
+                })}
               </div>
               <div className="flex justify-center pt-2">
                 <SoundsHighlightButton

--- a/src/components/StudyPane/InfoPane/Sounds.tsx
+++ b/src/components/StudyPane/InfoPane/Sounds.tsx
@@ -39,6 +39,11 @@ const DistributionChip = ({
       ? "outline outline-offset-1 outline-[3px] outline-[#FFC300] drop-shadow-sm"
       : "outline-offset-[-4px]";
 
+  // Colors only show when highlighted — default is white/gray (matching PDF page 7)
+  const chipFill = isHighlighted ? (fill ?? "#FFFFFF") : "#FFFFFF";
+  const chipBorder = isHighlighted ? (border ?? "#D9D9D9") : "#D9D9D9";
+  const chipText = isHighlighted ? (text ?? "#525252") : "#525252";
+
   return (
     <div className="my-1 flex">
       <button
@@ -46,9 +51,9 @@ const DistributionChip = ({
         onClick={onClick}
         className={`wordBlock mx-1 flex rounded border ${statusClassName}`}
         style={{
-          background: fill ?? "#FFFFFF",
-          border: `2px solid ${border ?? "#D9D9D9"}`,
-          color: text ?? "#525252",
+          background: chipFill,
+          border: `2px solid ${chipBorder}`,
+          color: chipText,
         }}
       >
         <span className="flex select-none items-center justify-center gap-2 px-3 py-1 text-center text-base leading-none hover:opacity-80">

--- a/src/components/StudyPane/InfoPane/Sounds.tsx
+++ b/src/components/StudyPane/InfoPane/Sounds.tsx
@@ -1,12 +1,300 @@
-import React from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 
-const Sounds = ({
-    
-}:{
-    
-}) => {
+import { FormatContext } from "..";
+import AccordionToggleIcon from "./common/AccordionToggleIcon";
+import {
+  countLetterOccurrences,
+  countSoundOccurrences,
+  LETTER_CHIPS,
+  SOUND_CHIPS,
+} from "@/lib/hebrewHighlights";
+
+type SoundsSectionId = "sound-distribution" | "letter-distribution";
+
+type DistributionChipProps = {
+  label: string;
+  count: number;
+  fill?: string;
+  border?: string;
+  text?: string;
+  isSelected: boolean;
+  isHighlighted: boolean;
+  onClick: () => void;
+};
+
+const DistributionChip = ({
+  label,
+  count,
+  fill,
+  border,
+  text,
+  isSelected,
+  isHighlighted,
+  onClick,
+}: DistributionChipProps) => {
+  const statusClassName = isHighlighted
+    ? "outline outline-offset-1 outline-[3px] outline-[#FFC300] drop-shadow-md"
+    : isSelected
+      ? "outline outline-offset-1 outline-[3px] outline-[#FFC300] drop-shadow-sm"
+      : "outline-offset-[-4px]";
+
   return (
-    <h1>Sounds</h1>
+    <div className="my-1 flex">
+      <button
+        type="button"
+        onClick={onClick}
+        className={`wordBlock mx-1 flex rounded border ${statusClassName}`}
+        style={{
+          background: fill ?? "#FFFFFF",
+          border: `2px solid ${border ?? "#D9D9D9"}`,
+          color: text ?? "#525252",
+        }}
+      >
+        <span className="flex select-none items-center justify-center gap-2 px-3 py-1 text-center text-base leading-none hover:opacity-80">
+          <span>{label}</span>
+          <span className="flex h-6.5 min-w-6.5 items-center justify-center rounded-full bg-[#EFEFEF] px-1 text-sm text-black">
+            {count}
+          </span>
+        </span>
+      </button>
+    </div>
   );
 };
+
+const SoundsHighlightButton = ({
+  active,
+  disabled,
+  onClick,
+}: {
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    className={`inline-flex items-center justify-center gap-2.5 rounded-full px-8 py-4 text-center font-medium transition lg:px-8 xl:px-10 ${
+      disabled
+        ? "cursor-not-allowed bg-slate-200 text-slate-500"
+        : active
+          ? "bg-slate-300 text-slate-800 hover:bg-slate-200"
+          : "bg-primary text-white hover:bg-opacity-90"
+    }`}
+    aria-pressed={active}
+  >
+    {active ? "Clear Highlight" : "Smart Highlight"}
+  </button>
+);
+
+const Sounds = () => {
+  const {
+    ctxPassageProps,
+    ctxSelectedSoundChipIds,
+    ctxSetSelectedSoundChipIds,
+    ctxSoundHighlightEnabled,
+    ctxSetSoundHighlightEnabled,
+    ctxSelectedLetterChipIds,
+    ctxSetSelectedLetterChipIds,
+    ctxLetterHighlightEnabled,
+    ctxSetLetterHighlightEnabled,
+  } = useContext(FormatContext);
+  const [openSection, setOpenSection] = useState<SoundsSectionId>("sound-distribution");
+
+  const toggleSection = (sectionId: SoundsSectionId) => {
+    setOpenSection((prev) => (prev === sectionId ? prev : sectionId));
+  };
+
+  const allWords = useMemo(() => {
+    const words = [];
+    for (const stanza of ctxPassageProps.stanzaProps) {
+      for (const strophe of stanza.strophes) {
+        for (const line of strophe.lines) {
+          for (const word of line.words) {
+            words.push(word);
+          }
+        }
+      }
+    }
+    return words;
+  }, [ctxPassageProps]);
+
+  const soundCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    SOUND_CHIPS.forEach((chip) => counts.set(chip.id, 0));
+
+    allWords.forEach((word) => {
+      SOUND_CHIPS.forEach((chip) => {
+        counts.set(chip.id, (counts.get(chip.id) || 0) + countSoundOccurrences(word, chip.id));
+      });
+    });
+
+    return counts;
+  }, [allWords]);
+
+  const letterCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    LETTER_CHIPS.forEach((chip) => counts.set(chip.id, 0));
+
+    allWords.forEach((word) => {
+      LETTER_CHIPS.forEach((chip) => {
+        counts.set(chip.id, (counts.get(chip.id) || 0) + countLetterOccurrences(word, chip.id));
+      });
+    });
+
+    return counts;
+  }, [allWords]);
+
+  useEffect(() => {
+    if (ctxSelectedSoundChipIds.length === 0 && ctxSoundHighlightEnabled) {
+      ctxSetSoundHighlightEnabled(false);
+    }
+  }, [ctxSelectedSoundChipIds, ctxSetSoundHighlightEnabled, ctxSoundHighlightEnabled]);
+
+  useEffect(() => {
+    if (ctxSelectedLetterChipIds.length === 0 && ctxLetterHighlightEnabled) {
+      ctxSetLetterHighlightEnabled(false);
+    }
+  }, [ctxSelectedLetterChipIds, ctxSetLetterHighlightEnabled, ctxLetterHighlightEnabled]);
+
+  const toggleSoundChip = (chipId: string) => {
+    ctxSetSelectedSoundChipIds(
+      ctxSelectedSoundChipIds.includes(chipId)
+        ? ctxSelectedSoundChipIds.filter((id) => id !== chipId)
+        : [...ctxSelectedSoundChipIds, chipId],
+    );
+  };
+
+  const toggleLetterChip = (chipId: string) => {
+    ctxSetSelectedLetterChipIds(
+      ctxSelectedLetterChipIds.includes(chipId)
+        ? ctxSelectedLetterChipIds.filter((id) => id !== chipId)
+        : [...ctxSelectedLetterChipIds, chipId],
+    );
+  };
+
+  const toggleSoundHighlight = () => {
+    if (ctxSelectedSoundChipIds.length === 0) {
+      return;
+    }
+
+    const next = !ctxSoundHighlightEnabled;
+    ctxSetSoundHighlightEnabled(next);
+    if (next) {
+      ctxSetLetterHighlightEnabled(false);
+    }
+  };
+
+  const toggleLetterHighlight = () => {
+    if (ctxSelectedLetterChipIds.length === 0) {
+      return;
+    }
+
+    const next = !ctxLetterHighlightEnabled;
+    ctxSetLetterHighlightEnabled(next);
+    if (next) {
+      ctxSetSoundHighlightEnabled(false);
+    }
+  };
+
+  const soundTooltip =
+    "Different Hebrew letters can produce similar sounds. This tool highlights sound patterns by how words are heard, not just how they are written. Sound highlights only appear in transliteration and Hebrew display modes.";
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <div className="accordion">
+        <div className="mx-4 border-b border-stroke dark:border-strokedark">
+          <button
+            type="button"
+            className="ClickBlock flex w-full items-center gap-2 px-2 py-4 text-left text-sm font-medium md:text-base"
+            onClick={() => toggleSection("sound-distribution")}
+          >
+            <AccordionToggleIcon isOpen={openSection === "sound-distribution"} />
+            <span className={openSection === "sound-distribution" ? "text-primary" : "text-black dark:text-white"}>
+              Hebrew Sound Distribution
+            </span>
+            <span
+              className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full border border-slate-300 text-xs text-slate-500"
+              title={soundTooltip}
+            >
+              i
+            </span>
+          </button>
+
+          {openSection === "sound-distribution" && (
+            <div className="space-y-4 p-4">
+              <div className="flex flex-wrap">
+                {SOUND_CHIPS.map((chip) => (
+                  <DistributionChip
+                    key={chip.id}
+                    label={chip.label}
+                    count={soundCounts.get(chip.id) || 0}
+                    fill={chip.palette.fill}
+                    border={chip.palette.border}
+                    text={chip.palette.text}
+                    isSelected={ctxSelectedSoundChipIds.includes(chip.id)}
+                    isHighlighted={ctxSoundHighlightEnabled && ctxSelectedSoundChipIds.includes(chip.id)}
+                    onClick={() => toggleSoundChip(chip.id)}
+                  />
+                ))}
+              </div>
+              <div className="flex justify-center pt-2">
+                <SoundsHighlightButton
+                  active={ctxSoundHighlightEnabled}
+                  disabled={ctxSelectedSoundChipIds.length === 0}
+                  onClick={toggleSoundHighlight}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="mx-4 border-b border-stroke dark:border-strokedark">
+          <button
+            type="button"
+            className="ClickBlock flex w-full items-center gap-2 px-2 py-4 text-left text-sm font-medium md:text-base"
+            onClick={() => toggleSection("letter-distribution")}
+          >
+            <AccordionToggleIcon isOpen={openSection === "letter-distribution"} />
+            <span className={openSection === "letter-distribution" ? "text-primary" : "text-black dark:text-white"}>
+              Hebrew Letter Distribution
+            </span>
+          </button>
+
+          {openSection === "letter-distribution" && (
+            <div className="space-y-4 p-4">
+              <div className="flex flex-wrap">
+                {LETTER_CHIPS.map((chip) => (
+                  <DistributionChip
+                    key={chip.id}
+                    label={chip.label}
+                    count={letterCounts.get(chip.id) || 0}
+                    fill={chip.palette.fill}
+                    border={chip.palette.border}
+                    text={chip.palette.text}
+                    isSelected={ctxSelectedLetterChipIds.includes(chip.id)}
+                    isHighlighted={ctxLetterHighlightEnabled && ctxSelectedLetterChipIds.includes(chip.id)}
+                    onClick={() => toggleLetterChip(chip.id)}
+                  />
+                ))}
+              </div>
+              <div className="flex justify-center pt-2">
+                <SoundsHighlightButton
+                  active={ctxLetterHighlightEnabled}
+                  disabled={ctxSelectedLetterChipIds.length === 0}
+                  onClick={toggleLetterHighlight}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="px-8 py-5 text-sm leading-6 text-slate-600">
+          Individual-letter highlights stay in the browser for now and are not saved to the database. You can still use the main formatting tools on words and strophes, but these sound and letter views act like browsing filters.
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export default Sounds;

--- a/src/components/StudyPane/InfoPane/Sounds.tsx
+++ b/src/components/StudyPane/InfoPane/Sounds.tsx
@@ -206,8 +206,10 @@ const Sounds = () => {
     }
   };
 
-  const soundTooltip =
-    "Different Hebrew letters can produce similar sounds. This tool helps you detect sound patterns and rhymes based on how words are heard, not how they are written. The highlighted Hebrew sound patterns are only visible in the English transliteration and Hebrew text, not in the default English display.";
+  const soundTooltipP1 =
+    "Different Hebrew letters can produce similar sounds. This tool helps you detect sound patterns and rhymes based on how words are heard, not how they are written.";
+  const soundTooltipP2 =
+    "The highlighted Hebrew sound patterns are only visible in the English transliteration and Hebrew text, not in the default English display.";
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
@@ -227,12 +229,13 @@ const Sounds = () => {
               onClick={(e) => { e.stopPropagation(); setShowTooltip((v) => !v); }}
               onMouseEnter={() => setShowTooltip(true)}
               onMouseLeave={() => setShowTooltip(false)}
-              title={soundTooltip}
+              title={`${soundTooltipP1}\n\n${soundTooltipP2}`}
             >
               i
               {showTooltip && (
-                <div className="absolute left-1/2 top-full z-50 mt-2 w-72 -translate-x-1/2 rounded-lg border border-slate-200 bg-white p-3 text-xs leading-relaxed text-slate-700 shadow-lg dark:border-strokedark dark:bg-boxdark dark:text-bodydark">
-                  {soundTooltip}
+                <div className="absolute left-1/2 top-full z-50 mt-2 w-72 -translate-x-1/2 rounded-lg border border-slate-200 bg-white p-4 text-xs leading-relaxed text-slate-700 shadow-lg dark:border-strokedark dark:bg-boxdark dark:text-bodydark">
+                  <p>{soundTooltipP1}</p>
+                  <p className="mt-3">{soundTooltipP2}</p>
                 </div>
               )}
             </span>

--- a/src/components/StudyPane/Passage/PassageBlock.tsx
+++ b/src/components/StudyPane/Passage/PassageBlock.tsx
@@ -4,15 +4,23 @@ import { useState, useEffect } from "react";
 import { StanzaBlock } from './StanzaBlock';
 import { LanguageMode } from '@/lib/types';
 
+export type PassageDisplayMode = "gloss" | "hebrew" | "transliteration";
+
 export const LanguageContext = createContext({
-  ctxIsHebrew: false
+  ctxIsHebrew: false,
+  ctxDisplayMode: "gloss" as PassageDisplayMode,
 })
 
-export const PassageBlock = ( {isHebrew}: {isHebrew: boolean} ) => {
+export const PassageBlock = ({
+  displayMode,
+}: {
+  displayMode: PassageDisplayMode;
+}) => {
 
   const { ctxPassageProps, ctxLanguageMode, ctxStropheNoteBtnOn } = useContext(FormatContext);
 
   const [isNarrow, setIsNarrow] = useState(false);
+  const isHebrew = displayMode === "hebrew";
 
   //check window size of passage
   useEffect(() => {
@@ -31,7 +39,8 @@ export const PassageBlock = ( {isHebrew}: {isHebrew: boolean} ) => {
   }, []);
 
   const languageContextValue = {
-    ctxIsHebrew: isHebrew
+    ctxIsHebrew: isHebrew,
+    ctxDisplayMode: displayMode,
   }
 
   const isParallel = ctxLanguageMode == LanguageMode.Parallel;
@@ -51,7 +60,7 @@ export const PassageBlock = ( {isHebrew}: {isHebrew: boolean} ) => {
 
   return (
     <LanguageContext.Provider value={languageContextValue}>
-    <div id={`selaPassage_${isHebrew ? 'heb' : 'eng'}`} className={`${passageWidthClass} max-w-full flex relative px-2 py-4`}>
+    <div id={`selaPassage_${displayMode}`} className={`${passageWidthClass} max-w-full flex relative px-2 py-4`}>
         <div className={`flex ${stanzaLayoutClass}`}>
         {
             ctxPassageProps.stanzaProps.map((stanza) => {

--- a/src/components/StudyPane/Passage/WordBlock.tsx
+++ b/src/components/StudyPane/Passage/WordBlock.tsx
@@ -7,6 +7,12 @@ import { wrapText, wordsHasSameColor } from "@/lib/utils";
 import EsvPopover from './EsvPopover';
 import { LanguageContext } from './PassageBlock';
 import { updateMetadataInDb } from '@/lib/actions';
+import {
+  buildHighlightedHebrewSegments,
+  buildHighlightedTransliterationSegments,
+  LETTER_CHIP_MAP,
+  SOUND_CHIP_MAP,
+} from '@/lib/hebrewHighlights';
 
 type ZoomLevel = {
   [level: number]: { fontSize: string, fontInPx: string, maxWidthPx: number };
@@ -38,18 +44,28 @@ export const WordBlock = ({
     ctxSetSelectedStrophes, ctxColorAction, ctxSelectedColor,
     ctxSetColorFill, ctxSetBorderColor, ctxSetTextColor,
     ctxWordsColorMap, ctxSetWordsColorMap, ctxStudyMetadata, ctxStudyId,
-    ctxAddToHistory, ctxInViewMode, ctxEditingWordId, ctxSetEditingWordId, ctxStudyBook
+    ctxAddToHistory, ctxInViewMode, ctxEditingWordId, ctxSetEditingWordId, ctxStudyBook,
+    ctxSelectedSoundChipIds, ctxSoundHighlightEnabled,
+    ctxSelectedLetterChipIds, ctxLetterHighlightEnabled,
   } = useContext(FormatContext)
 
-  const { ctxIsHebrew } = useContext(LanguageContext)
+  const { ctxIsHebrew, ctxDisplayMode } = useContext(LanguageContext)
 
   const [isEditingGloss, setIsEditingGloss] = useState(false);
   const [glossDraft, setGlossDraft] = useState(wordProps.metadata?.glossOverride ?? wordProps.gloss ?? "");
   const glossInputRef = useRef<HTMLTextAreaElement | null>(null);
   const [glossEditWidth, setGlossEditWidth] = useState<number | null>(null);
   const skipBlurCommitRef = useRef(false);
-  const canEditEnglish = !ctxIsHebrew && !ctxInViewMode;
+  const canEditEnglish = ctxDisplayMode === "gloss" && !ctxInViewMode;
   const currentGlossValue = wordProps.metadata?.glossOverride ?? wordProps.gloss ?? "";
+  const transliterationValue = wordProps.wordInformation?.transliteration?.trim() || "";
+  const hebrewValue = wordProps.wordInformation?.hebrew?.trim() || wordProps.wlcWord || "";
+  const displayValue =
+    ctxDisplayMode === "hebrew"
+      ? hebrewValue
+      : ctxDisplayMode === "transliteration"
+        ? transliterationValue
+        : currentGlossValue;
 
   const mapColor = ctxWordsColorMap.get(wordProps.wordId);
   const metaColor = ctxStudyMetadata.words[wordProps.wordId]?.color ?? wordProps.metadata?.color;
@@ -270,11 +286,11 @@ export const WordBlock = ({
       const context = canvas.getContext('2d');
       if (context) {
         context.font = zoomLevelMap[DEFAULT_ZOOM_LEVEL].fontInPx + " Satoshi";
-        let currentLineCount = wrapText(wordProps.gloss.trim(), context, zoomLevelMap[DEFAULT_ZOOM_LEVEL].maxWidthPx /*(index === 0) ? 90 : 96*/);
+        let currentLineCount = wrapText(displayValue.trim(), context, zoomLevelMap[DEFAULT_ZOOM_LEVEL].maxWidthPx /*(index === 0) ? 90 : 96*/);
         let currentZoomLevel = DEFAULT_ZOOM_LEVEL - 1;
         while (currentLineCount > 2 && currentZoomLevel >= 0) {
           context.font = zoomLevelMap[currentZoomLevel].fontInPx + " Satoshi";
-          currentLineCount = wrapText(wordProps.gloss.trim(), context, zoomLevelMap[DEFAULT_ZOOM_LEVEL].maxWidthPx);
+          currentLineCount = wrapText(displayValue.trim(), context, zoomLevelMap[DEFAULT_ZOOM_LEVEL].maxWidthPx);
           fontSize = zoomLevelMap[currentZoomLevel].fontSize;
           currentZoomLevel--;
         }
@@ -327,6 +343,71 @@ export const WordBlock = ({
     );
   };
 
+  const selectedSoundIds = ctxSoundHighlightEnabled
+    ? new Set(ctxSelectedSoundChipIds)
+    : new Set<string>();
+  const selectedLetterIds = ctxLetterHighlightEnabled
+    ? new Set(ctxSelectedLetterChipIds)
+    : new Set<string>();
+
+  const renderInlineHighlightSegments = () => {
+    if (ctxDisplayMode === "transliteration") {
+      const segments = buildHighlightedTransliterationSegments(
+        transliterationValue,
+        selectedSoundIds,
+      );
+
+      return segments.map((segment, index) => {
+        const palette = segment.highlightId
+          ? SOUND_CHIP_MAP.get(segment.highlightId)?.palette
+          : undefined;
+
+        return (
+          <span
+            key={`${wordProps.wordId}-translit-${index}`}
+            style={palette ? {
+              backgroundColor: palette.fill,
+              color: palette.text,
+              boxShadow: `inset 0 0 0 1px ${palette.border ?? DEFAULT_BORDER_COLOR}`,
+              borderRadius: 4,
+              paddingInline: "1px",
+            } : undefined}
+          >
+            {segment.text}
+          </span>
+        );
+      });
+    }
+
+    const segments = buildHighlightedHebrewSegments(
+      hebrewValue,
+      selectedSoundIds,
+      selectedLetterIds,
+    );
+
+    return segments.map((segment, index) => {
+      const palette = segment.highlightId
+        ? SOUND_CHIP_MAP.get(segment.highlightId)?.palette ??
+          LETTER_CHIP_MAP.get(segment.highlightId)?.palette
+        : undefined;
+
+      return (
+        <span
+          key={`${wordProps.wordId}-hebrew-${index}`}
+          style={palette ? {
+            backgroundColor: palette.fill,
+            color: palette.text,
+            boxShadow: `inset 0 0 0 1px ${palette.border ?? DEFAULT_BORDER_COLOR}`,
+            borderRadius: 4,
+            paddingInline: "1px",
+          } : undefined}
+        >
+          {segment.text}
+        </span>
+      );
+    });
+  };
+
   return (
     <div className="flex">
       {/* Show indents when uniformBoxes style is enabled */}
@@ -368,7 +449,7 @@ export const WordBlock = ({
               ${ctxBoxDisplayConfig.style === BoxDisplayStyle.uniformBoxes && (ctxIsHebrew ? hebBlockSizeStyle : engBlockSizeStyle)} relative`}
             data-clicktype="clickable"
           >
-            {ctxIsHebrew ? wordProps.wlcWord : (
+            {ctxDisplayMode === "gloss" ? (
               isEditingGloss ? (
                 <>
                   <textarea
@@ -391,7 +472,7 @@ export const WordBlock = ({
                   />
                 </>
               ) : currentGlossValue
-            )}
+            ) : renderInlineHighlightSegments()}
           </span>
         </span>
       </div>

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -27,7 +27,8 @@ const Passage = ({
   } = useContext(FormatContext);
 
   const nonEnglishDisplayMode =
-    ctxNonEnglishDisplayMode === NonEnglishDisplayMode.Transliteration
+    ctxNonEnglishDisplayMode === NonEnglishDisplayMode.Transliteration ||
+    ctxNonEnglishDisplayMode === NonEnglishDisplayMode.HebrewTransliteration
       ? "transliteration"
       : "hebrew";
 

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -4,7 +4,7 @@ import { FormatContext } from '../index';
 import { PassageBlock } from './PassageBlock';
 
 import { WordProps } from '@/lib/data';
-import { StropheNote, StructureUpdateType, StudyNotes, LanguageMode } from '@/lib/types';
+import { StropheNote, StructureUpdateType, StudyNotes, LanguageMode, NonEnglishDisplayMode } from '@/lib/types';
 import { updateMetadataInDb } from '@/lib/actions';
 import { eventBus } from "@/lib/eventBus";
 import { mergeData, extractIdenticalWordsFromPassage } from '@/lib/utils';
@@ -22,8 +22,14 @@ const Passage = ({
     ctxSetStudyMetadata, ctxSelectedWords, ctxSetSelectedWords, ctxSetNumSelectedWords,
     ctxSelectedStrophes, ctxSetSelectedStrophes, ctxSetNumSelectedStrophes,
     ctxStructureUpdateType, ctxSetStructureUpdateType, ctxAddToHistory, 
-    ctxStudyNotes, ctxSetStudyNotes, ctxSetNoteMerge, ctxLanguageMode, ctxStropheNoteBtnOn
+    ctxStudyNotes, ctxSetStudyNotes, ctxSetNoteMerge, ctxLanguageMode, ctxStropheNoteBtnOn,
+    ctxNonEnglishDisplayMode,
   } = useContext(FormatContext);
+
+  const nonEnglishDisplayMode =
+    ctxNonEnglishDisplayMode === NonEnglishDisplayMode.Transliteration
+      ? "transliteration"
+      : "hebrew";
 
   const { isDragging, handleMouseDown, containerRef, getSelectionBoxStyle } = useDragToSelect(ctxPassageProps);
 
@@ -474,18 +480,18 @@ const Passage = ({
       >
         { ctxLanguageMode == LanguageMode.English && 
           <div className={`flex flex-row mx-auto ${ctxStropheNoteBtnOn ? 'w-fit min-w-full' : 'w-[100%]'}`}>
-            <PassageBlock isHebrew={false}/> 
+            <PassageBlock displayMode="gloss"/> 
           </div>
         }
         { ctxLanguageMode == LanguageMode.Parallel && 
           <div className={`flex flex-row mx-auto ${(ctxStropheNoteBtnOn || ctxLanguageMode == LanguageMode.Parallel) ? 'w-fit max-w-full' : 'w-[100%]'}`}>
-            <PassageBlock isHebrew={true}/>
-            <PassageBlock isHebrew={false}/>
+            <PassageBlock displayMode={nonEnglishDisplayMode}/>
+            <PassageBlock displayMode="gloss"/>
           </div>
         }
         { ctxLanguageMode == LanguageMode.Hebrew && 
           <div className={`flex flex-row mx-auto ${ctxStropheNoteBtnOn ? 'w-fit min-w-full' : 'w-[100%]'}`}>
-          <PassageBlock isHebrew={true}/> 
+          <PassageBlock displayMode={nonEnglishDisplayMode}/> 
           </div>
         }
       </div>

--- a/src/components/StudyPane/Toolbar/index.tsx
+++ b/src/components/StudyPane/Toolbar/index.tsx
@@ -42,19 +42,20 @@ const Toolbar = ({
       { // only show zoom in/out & uniform width buttons in view only mode
         ctxInViewMode ?
           (
-            <div className="flex flex-row space-x-4">
+            <div className="flex flex-row items-center justify-between space-x-4">
               <div className="flex h-8 basis-1/3 items-center justify-left">
                 <ScaleDropDown setScaleValue={setScaleValue} />
                 <UniformWidthBtn setBoxStyle={setBoxStyle} />
               </div>
-              {
-                (study.model) &&
-                (
-                  <div className="flex h-8 basis-2/3 items-center justify-end">
+              <div className="flex h-8 basis-2/3 items-center justify-end gap-3">
+                <LanguageSwitcher />
+                {
+                  (study.model) &&
+                  (
                     <StudyBtn setCloneStudyOpen={setCloneStudyOpen} />
-                  </div>
-                )
-              }
+                  )
+                }
+              </div>
             </div>
           )
         : (

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -9,7 +9,7 @@ import InfoPane from "./InfoPane";
 import { Footer } from "./Footer";
 
 import { ColorData, ColorSource, PassageData, PassageStaticData, PassageProps, StropheProps, WordProps, StudyMetadata, StanzaMetadata, StropheMetadata, WordMetadata } from '@/lib/data';
-import { ColorActionType, InfoPaneActionType, StructureUpdateType, BoxDisplayStyle, BoxDisplayConfig, LanguageMode } from "@/lib/types";
+import { ColorActionType, InfoPaneActionType, StructureUpdateType, BoxDisplayStyle, BoxDisplayConfig, LanguageMode, NonEnglishDisplayMode } from "@/lib/types";
 import { mergeData, wordsHasSameColor } from "@/lib/utils";
 import { updateMetadataInDb } from '@/lib/actions';
 import { DEFAULT_BORDER_COLOR, DEFAULT_COLOR_FILL, DEFAULT_TEXT_COLOR } from "@/lib/colors";
@@ -102,6 +102,16 @@ export const FormatContext = createContext({
   ctxAddToHistory: (metadata: StudyMetadata, options?: HistorySnapshotOptions) => {},
   ctxLanguageMode: {} as LanguageMode,
   ctxSetLanguageMode: (arg: LanguageMode) => {},
+  ctxNonEnglishDisplayMode: NonEnglishDisplayMode.Hebrew,
+  ctxSetNonEnglishDisplayMode: (arg: NonEnglishDisplayMode) => {},
+  ctxSelectedSoundChipIds: [] as string[],
+  ctxSetSelectedSoundChipIds: (arg: string[]) => {},
+  ctxSoundHighlightEnabled: false,
+  ctxSetSoundHighlightEnabled: (arg: boolean) => {},
+  ctxSelectedLetterChipIds: [] as string[],
+  ctxSetSelectedLetterChipIds: (arg: string[]) => {},
+  ctxLetterHighlightEnabled: false,
+  ctxSetLetterHighlightEnabled: (arg: boolean) => {},
   ctxNoteBox: undefined as undefined|DOMRect,
   ctxSetNoteBox: (arg: undefined|DOMRect) => {},
   ctxNoteMerge: true,
@@ -171,7 +181,14 @@ const StudyPane = ({
 
   // set default language to English
   const [languageMode, setLanguageMode] = useState<LanguageMode>(LanguageMode.English);
+  const [nonEnglishDisplayMode, setNonEnglishDisplayMode] = useState<NonEnglishDisplayMode>(
+    NonEnglishDisplayMode.Hebrew,
+  );
   const [editingWordId, setEditingWordId] = useState<number | null>(null);
+  const [selectedSoundChipIds, setSelectedSoundChipIds] = useState<string[]>([]);
+  const [soundHighlightEnabled, setSoundHighlightEnabled] = useState(false);
+  const [selectedLetterChipIds, setSelectedLetterChipIds] = useState<string[]>([]);
+  const [letterHighlightEnabled, setLetterHighlightEnabled] = useState(false);
 
   const [noteBox, setNoteBox] = useState(undefined as undefined|DOMRect);
   const [noteMerge, setNoteMerge] = useState(true);
@@ -293,6 +310,16 @@ const StudyPane = ({
     ctxAddToHistory: addToHistory,
     ctxLanguageMode: languageMode,
     ctxSetLanguageMode: setLanguageMode,
+    ctxNonEnglishDisplayMode: nonEnglishDisplayMode,
+    ctxSetNonEnglishDisplayMode: setNonEnglishDisplayMode,
+    ctxSelectedSoundChipIds: selectedSoundChipIds,
+    ctxSetSelectedSoundChipIds: setSelectedSoundChipIds,
+    ctxSoundHighlightEnabled: soundHighlightEnabled,
+    ctxSetSoundHighlightEnabled: setSoundHighlightEnabled,
+    ctxSelectedLetterChipIds: selectedLetterChipIds,
+    ctxSetSelectedLetterChipIds: setSelectedLetterChipIds,
+    ctxLetterHighlightEnabled: letterHighlightEnabled,
+    ctxSetLetterHighlightEnabled: setLetterHighlightEnabled,
     ctxNoteBox: noteBox,
     ctxSetNoteBox: setNoteBox,
     ctxNoteMerge: noteMerge,
@@ -328,6 +355,9 @@ const StudyPane = ({
     
     setBoxDisplayConfig(boxConfig || { style: BoxDisplayStyle.box });
     setLanguageMode(studyMetadata.lang || LanguageMode.English);
+    setNonEnglishDisplayMode(
+      studyMetadata.nonEnglishDisplayMode ?? NonEnglishDisplayMode.Hebrew,
+    );
   
   }, [passageData.bibleData, studyMetadata]);
 
@@ -358,7 +388,7 @@ const StudyPane = ({
 
         {/* Main Content */}
         <div className="flex flex-1 overflow-hidden pt-32 pb-14 max-[645px]:!pb-0">
-          <main className={`flex flex-row overflow-y-auto overflow-x-auto relative h-full flex-1 ${languageMode == LanguageMode.Hebrew ? "hbFont" : ""}`}>
+          <main className={`flex flex-row overflow-y-auto overflow-x-auto relative h-full flex-1 ${languageMode == LanguageMode.Hebrew && nonEnglishDisplayMode == NonEnglishDisplayMode.Hebrew ? "hbFont" : ""}`}>
             {/* Scrollable Passage Pane */}
             <Passage bibleData={passageData.bibleData}/>
             {

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -859,12 +859,15 @@ export async function fetchPassageData(studyId: string) {
           })();
 
           const hebrewWord = (() => {
-            const stepBibleHebrew = wordInfo?.Hebrew?.trim();
-            if (stepBibleHebrew && stepBibleHebrew.length > 0) {
-              return stepBibleHebrew;
-            }
+            // Use WLC passage text as primary source (actual Hebrew text with vowel points).
+            // StepBible Hebrew is the dictionary citation form (without prefixes/suffixes)
+            // and should only be used as a fallback.
             const wlcHebrew = hebWord.wlcWord?.trim();
-            return wlcHebrew && wlcHebrew.length > 0 ? wlcHebrew : "";
+            if (wlcHebrew && wlcHebrew.length > 0) {
+              return wlcHebrew;
+            }
+            const stepBibleHebrew = wordInfo?.Hebrew?.trim();
+            return stepBibleHebrew && stepBibleHebrew.length > 0 ? stepBibleHebrew : "";
           })();
 
           const gloss = (() => {
@@ -890,6 +893,9 @@ export async function fetchPassageData(studyId: string) {
 
           hebWord.wordInformation = {
             hebrew: hebrewWord,
+            // TODO: Transliteration currently comes from stepbible_tbesh (lexical/dictionary form).
+            // The PDF spec requires OHB transliteration (with prefixes, e.g. "le.da.vid" not "da.vid").
+            // This needs a new heb_bible column with OHB transliteration data to match the spec exactly.
             transliteration: wordInfo?.Transliteration?.trim() || "",
             gloss: cleanGlossValue(gloss),
             morphology: preferredMorphology,

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,4 +1,4 @@
-import { BoxDisplayConfig, LanguageMode } from "@/lib/types"
+import { BoxDisplayConfig, LanguageMode, NonEnglishDisplayMode } from "@/lib/types"
 
 export type ColorSource = "syntax" | "motif";
 
@@ -47,6 +47,7 @@ export type StudyMetadata = {
     scaleValue?: number;
     boxStyle?: BoxDisplayConfig;
     lang?: LanguageMode;
+    nonEnglishDisplayMode?: NonEnglishDisplayMode;
 }
 
 export interface StudyProps {

--- a/src/lib/hebrewHighlights.ts
+++ b/src/lib/hebrewHighlights.ts
@@ -39,25 +39,25 @@ const createPalette = (fill: string, text = DEFAULT_TEXT_COLOR): InlinePalette =
   });
 
 export const SOUND_CHIPS: SoundChip[] = [
-  { id: "s", label: "s", palette: createPalette("#FFEB3B") },
-  { id: "sh", label: "sh", palette: createPalette("#FF9800") },
-  { id: "ts", label: "ts", palette: createPalette("#4FC3F7") },
-  { id: "z", label: "z", palette: createPalette("#81C784") },
-  { id: "kh-ch", label: "kh/ch", palette: createPalette("#F06292", "#FFFFFF") },
-  { id: "k-q", label: "k/q", palette: createPalette("#9575CD", "#FFFFFF") },
-  { id: "g", label: "g", palette: createPalette("#4DB6AC") },
-  { id: "h", label: "h", palette: createPalette("#FFF176") },
-  { id: "d", label: "d", palette: createPalette("#E57373") },
-  { id: "t", label: "t", palette: createPalette("#64B5F6") },
-  { id: "n", label: "n", palette: createPalette("#AED581") },
-  { id: "m", label: "m", palette: createPalette("#F8BBD0") },
-  { id: "b", label: "b", palette: createPalette("#7986CB", "#FFFFFF") },
-  { id: "v", label: "v", palette: createPalette("#80CBC4") },
-  { id: "p", label: "p", palette: createPalette("#FFB74D") },
-  { id: "f", label: "f", palette: createPalette("#B39DDB") },
-  { id: "l", label: "l", palette: createPalette("#B3E5FC") },
-  { id: "r", label: "r", palette: createPalette("#C5CAE9") },
-  { id: "y", label: "y", palette: createPalette("#DCEDC8") },
+  { id: "s", label: "s", palette: createPalette("#FFF9C4") },          // light yellow
+  { id: "sh", label: "sh", palette: createPalette("#FFD54F") },        // amber/gold
+  { id: "ts", label: "ts", palette: createPalette("#C5E1A5") },        // light green (NOT blue)
+  { id: "z", label: "z", palette: createPalette("#FFB74D") },          // orange
+  { id: "kh-ch", label: "kh/ch", palette: createPalette("#CE93D8") },  // purple/mauve
+  { id: "k-q", label: "k/q", palette: createPalette("#E1BEE7") },     // light purple
+  { id: "g", label: "g", palette: createPalette("#81C784") },          // green
+  { id: "h", label: "h", palette: createPalette("#FF9800") },          // orange (bright)
+  { id: "d", label: "d", palette: createPalette("#EF9A9A") },          // salmon/pink
+  { id: "t", label: "t", palette: createPalette("#F44336", "#FFFFFF") }, // red
+  { id: "n", label: "n", palette: createPalette("#66BB6A") },          // bright green
+  { id: "m", label: "m", palette: createPalette("#E53935", "#FFFFFF") }, // bright red
+  { id: "b", label: "b", palette: createPalette("#A1887F") },          // brown
+  { id: "v", label: "v", palette: createPalette("#90A4AE") },          // gray
+  { id: "p", label: "p", palette: createPalette("#64B5F6") },          // light blue
+  { id: "f", label: "f", palette: createPalette("#B39DDB") },          // light purple
+  { id: "l", label: "l", palette: createPalette("#2196F3", "#FFFFFF") }, // blue
+  { id: "r", label: "r", palette: createPalette("#009688", "#FFFFFF") }, // teal
+  { id: "y", label: "y", palette: createPalette("#AED581") },          // green (light)
 ];
 
 export const LETTER_CHIPS: LetterChip[] = [

--- a/src/lib/hebrewHighlights.ts
+++ b/src/lib/hebrewHighlights.ts
@@ -93,6 +93,46 @@ export const LETTER_CHIPS: LetterChip[] = [
 export const SOUND_CHIP_MAP = new Map(SOUND_CHIPS.map((chip) => [chip.id, chip]));
 export const LETTER_CHIP_MAP = new Map(LETTER_CHIPS.map((chip) => [chip.id, chip]));
 
+/**
+ * Grouped letter chips for display. Final forms share a single chip
+ * with the base letter (e.g. כ ך), matching the PDF spec that shows
+ * 22 grouped chips rather than 27 individual ones.
+ *
+ * The `memberIds` array lists the individual LETTER_CHIP ids that belong
+ * to the group. Selecting a group selects/deselects all member ids.
+ */
+export type LetterChipGroup = {
+  id: string;
+  label: string;
+  memberIds: string[];
+  palette: InlinePalette;
+};
+
+export const LETTER_CHIP_GROUPS: LetterChipGroup[] = [
+  { id: "aleph", label: "א", memberIds: ["aleph"], palette: createPalette("#FFECB3") },
+  { id: "bet", label: "ב", memberIds: ["bet"], palette: createPalette("#C5CAE9") },
+  { id: "gimel", label: "ג", memberIds: ["gimel"], palette: createPalette("#B2DFDB") },
+  { id: "dalet", label: "ד", memberIds: ["dalet"], palette: createPalette("#FFCDD2") },
+  { id: "he", label: "ה", memberIds: ["he"], palette: createPalette("#FFF9C4") },
+  { id: "vav", label: "ו", memberIds: ["vav"], palette: createPalette("#B3E5FC") },
+  { id: "zayin", label: "ז", memberIds: ["zayin"], palette: createPalette("#C8E6C9") },
+  { id: "het", label: "ח", memberIds: ["het"], palette: createPalette("#F8BBD0") },
+  { id: "tet", label: "ט", memberIds: ["tet"], palette: createPalette("#E1BEE7") },
+  { id: "yod", label: "י", memberIds: ["yod"], palette: createPalette("#DCEDC8") },
+  { id: "kaf-group", label: "כ ך", memberIds: ["kaf", "final-kaf"], palette: createPalette("#D1C4E9") },
+  { id: "lamed", label: "ל", memberIds: ["lamed"], palette: createPalette("#BBDEFB") },
+  { id: "mem-group", label: "מ ם", memberIds: ["mem", "final-mem"], palette: createPalette("#F0F4C3") },
+  { id: "nun-group", label: "נ ן", memberIds: ["nun", "final-nun"], palette: createPalette("#FFE0B2") },
+  { id: "samekh", label: "ס", memberIds: ["samekh"], palette: createPalette("#FFEB3B") },
+  { id: "ayin", label: "ע", memberIds: ["ayin"], palette: createPalette("#CFD8DC") },
+  { id: "pe", label: "פ", memberIds: ["pe"], palette: createPalette("#FFD54F") },
+  { id: "tsadi-group", label: "צ ץ", memberIds: ["tsadi", "final-tsadi"], palette: createPalette("#4FC3F7") },
+  { id: "qof", label: "ק", memberIds: ["qof"], palette: createPalette("#9575CD", "#FFFFFF") },
+  { id: "resh", label: "ר", memberIds: ["resh"], palette: createPalette("#90A4AE") },
+  { id: "shin-sin-group", label: "שׂ שׁ", memberIds: ["sin", "shin"], palette: createPalette("#FF9800") },
+  { id: "tav", label: "ת", memberIds: ["tav"], palette: createPalette("#64B5F6") },
+];
+
 const transliterationPatterns: TransliterationPattern[] = [
   { text: "kh", soundId: "kh-ch" },
   { text: "ch", soundId: "kh-ch" },

--- a/src/lib/hebrewHighlights.ts
+++ b/src/lib/hebrewHighlights.ts
@@ -31,12 +31,11 @@ export type InlineTextSegment = {
   highlightId?: string;
 };
 
-const createPalette = (fill: string, text = DEFAULT_TEXT_COLOR): InlinePalette =>
-  clampPaletteToUserColors({
-    fill,
-    border: DEFAULT_BORDER_COLOR,
-    text,
-  });
+const createPalette = (fill: string, text = DEFAULT_TEXT_COLOR): InlinePalette => ({
+  fill,
+  border: DEFAULT_BORDER_COLOR,
+  text,
+});
 
 export const SOUND_CHIPS: SoundChip[] = [
   { id: "s", label: "s", palette: createPalette("#F8F070") },          // yellow-green

--- a/src/lib/hebrewHighlights.ts
+++ b/src/lib/hebrewHighlights.ts
@@ -39,25 +39,25 @@ const createPalette = (fill: string, text = DEFAULT_TEXT_COLOR): InlinePalette =
   });
 
 export const SOUND_CHIPS: SoundChip[] = [
-  { id: "s", label: "s", palette: createPalette("#FFF176") },          // yellow 300
-  { id: "sh", label: "sh", palette: createPalette("#FFB74D") },        // orange 300
-  { id: "ts", label: "ts", palette: createPalette("#AED581") },        // light green 300
-  { id: "z", label: "z", palette: createPalette("#4FC3F7") },          // light blue 300
-  { id: "kh-ch", label: "kh/ch", palette: createPalette("#BA68C8") },  // purple 300
-  { id: "k-q", label: "k/q", palette: createPalette("#9575CD") },      // deep purple 300
-  { id: "g", label: "g", palette: createPalette("#81C784") },          // green 300
-  { id: "h", label: "h", palette: createPalette("#FFD54F") },          // amber 300
-  { id: "d", label: "d", palette: createPalette("#E57373") },          // red 300
-  { id: "t", label: "t", palette: createPalette("#64B5F6") },          // blue 300
-  { id: "n", label: "n", palette: createPalette("#4DB6AC") },          // teal 300
-  { id: "m", label: "m", palette: createPalette("#F06292") },          // pink 300
-  { id: "b", label: "b", palette: createPalette("#A1887F") },          // brown 300
-  { id: "v", label: "v", palette: createPalette("#DCE775") },          // lime 300
-  { id: "p", label: "p", palette: createPalette("#4DD0E1") },          // cyan 300
-  { id: "f", label: "f", palette: createPalette("#FF8A65") },          // deep orange 300
-  { id: "l", label: "l", palette: createPalette("#7986CB") },          // indigo 300
-  { id: "r", label: "r", palette: createPalette("#90A4AE") },          // blue gray 300
-  { id: "y", label: "y", palette: createPalette("#F8BBD0") },          // pink 200
+  { id: "s", label: "s", palette: createPalette("#F8F070") },          // yellow-green
+  { id: "sh", label: "sh", palette: createPalette("#F8D048") },        // gold
+  { id: "ts", label: "ts", palette: createPalette("#F8B048") },        // orange
+  { id: "z", label: "z", palette: createPalette("#F89800") },          // dark orange
+  { id: "kh-ch", label: "kh/ch", palette: createPalette("#D0C0E8") },  // light purple
+  { id: "k-q", label: "k/q", palette: createPalette("#9070C8") },      // deep purple
+  { id: "g", label: "g", palette: createPalette("#B868C8") },          // purple
+  { id: "h", label: "h", palette: createPalette("#E0B8E0") },          // pink-purple
+  { id: "d", label: "d", palette: createPalette("#80C080") },          // green
+  { id: "t", label: "t", palette: createPalette("#48A850") },          // dark green
+  { id: "n", label: "n", palette: createPalette("#E07070") },          // red
+  { id: "m", label: "m", palette: createPalette("#F04030", "#FFFFFF") }, // bright red
+  { id: "b", label: "b", palette: createPalette("#A08878") },          // brown
+  { id: "v", label: "v", palette: createPalette("#D7CCC8") },          // warm gray
+  { id: "p", label: "p", palette: createPalette("#90A0A8") },          // cool gray
+  { id: "f", label: "f", palette: createPalette("#CFD8DC") },          // light gray-blue
+  { id: "l", label: "l", palette: createPalette("#2090F0", "#FFFFFF") }, // blue
+  { id: "r", label: "r", palette: createPalette("#60B0F0") },          // light blue
+  { id: "y", label: "y", palette: createPalette("#B8D8F8") },          // very light blue
 ];
 
 export const LETTER_CHIPS: LetterChip[] = [

--- a/src/lib/hebrewHighlights.ts
+++ b/src/lib/hebrewHighlights.ts
@@ -39,25 +39,25 @@ const createPalette = (fill: string, text = DEFAULT_TEXT_COLOR): InlinePalette =
   });
 
 export const SOUND_CHIPS: SoundChip[] = [
-  { id: "s", label: "s", palette: createPalette("#FFF9C4") },          // light yellow
-  { id: "sh", label: "sh", palette: createPalette("#FFD54F") },        // amber/gold
-  { id: "ts", label: "ts", palette: createPalette("#C5E1A5") },        // light green (NOT blue)
-  { id: "z", label: "z", palette: createPalette("#FFB74D") },          // orange
-  { id: "kh-ch", label: "kh/ch", palette: createPalette("#CE93D8") },  // purple/mauve
-  { id: "k-q", label: "k/q", palette: createPalette("#E1BEE7") },     // light purple
-  { id: "g", label: "g", palette: createPalette("#81C784") },          // green
-  { id: "h", label: "h", palette: createPalette("#FF9800") },          // orange (bright)
-  { id: "d", label: "d", palette: createPalette("#EF9A9A") },          // salmon/pink
-  { id: "t", label: "t", palette: createPalette("#F44336", "#FFFFFF") }, // red
-  { id: "n", label: "n", palette: createPalette("#66BB6A") },          // bright green
-  { id: "m", label: "m", palette: createPalette("#E53935", "#FFFFFF") }, // bright red
-  { id: "b", label: "b", palette: createPalette("#A1887F") },          // brown
-  { id: "v", label: "v", palette: createPalette("#90A4AE") },          // gray
-  { id: "p", label: "p", palette: createPalette("#64B5F6") },          // light blue
-  { id: "f", label: "f", palette: createPalette("#B39DDB") },          // light purple
-  { id: "l", label: "l", palette: createPalette("#2196F3", "#FFFFFF") }, // blue
-  { id: "r", label: "r", palette: createPalette("#009688", "#FFFFFF") }, // teal
-  { id: "y", label: "y", palette: createPalette("#AED581") },          // green (light)
+  { id: "s", label: "s", palette: createPalette("#FFF176") },          // yellow 300
+  { id: "sh", label: "sh", palette: createPalette("#FFB74D") },        // orange 300
+  { id: "ts", label: "ts", palette: createPalette("#AED581") },        // light green 300
+  { id: "z", label: "z", palette: createPalette("#4FC3F7") },          // light blue 300
+  { id: "kh-ch", label: "kh/ch", palette: createPalette("#BA68C8") },  // purple 300
+  { id: "k-q", label: "k/q", palette: createPalette("#9575CD") },      // deep purple 300
+  { id: "g", label: "g", palette: createPalette("#81C784") },          // green 300
+  { id: "h", label: "h", palette: createPalette("#FFD54F") },          // amber 300
+  { id: "d", label: "d", palette: createPalette("#E57373") },          // red 300
+  { id: "t", label: "t", palette: createPalette("#64B5F6") },          // blue 300
+  { id: "n", label: "n", palette: createPalette("#4DB6AC") },          // teal 300
+  { id: "m", label: "m", palette: createPalette("#F06292") },          // pink 300
+  { id: "b", label: "b", palette: createPalette("#A1887F") },          // brown 300
+  { id: "v", label: "v", palette: createPalette("#DCE775") },          // lime 300
+  { id: "p", label: "p", palette: createPalette("#4DD0E1") },          // cyan 300
+  { id: "f", label: "f", palette: createPalette("#FF8A65") },          // deep orange 300
+  { id: "l", label: "l", palette: createPalette("#7986CB") },          // indigo 300
+  { id: "r", label: "r", palette: createPalette("#90A4AE") },          // blue gray 300
+  { id: "y", label: "y", palette: createPalette("#F8BBD0") },          // pink 200
 ];
 
 export const LETTER_CHIPS: LetterChip[] = [

--- a/src/lib/hebrewHighlights.ts
+++ b/src/lib/hebrewHighlights.ts
@@ -1,0 +1,361 @@
+import { DEFAULT_BORDER_COLOR, DEFAULT_TEXT_COLOR, clampPaletteToUserColors } from "@/lib/colors";
+import { ColorData, WordProps } from "@/lib/data";
+
+type InlinePalette = Omit<ColorData, "source">;
+
+export type SoundChip = {
+  id: string;
+  label: string;
+  palette: InlinePalette;
+};
+
+export type LetterChip = {
+  id: string;
+  label: string;
+  palette: InlinePalette;
+};
+
+type TransliterationPattern = {
+  text: string;
+  soundId: string;
+};
+
+type HebrewClusterMatch = {
+  text: string;
+  letterId?: string;
+  soundIds: string[];
+};
+
+export type InlineTextSegment = {
+  text: string;
+  highlightId?: string;
+};
+
+const createPalette = (fill: string, text = DEFAULT_TEXT_COLOR): InlinePalette =>
+  clampPaletteToUserColors({
+    fill,
+    border: DEFAULT_BORDER_COLOR,
+    text,
+  });
+
+export const SOUND_CHIPS: SoundChip[] = [
+  { id: "s", label: "s", palette: createPalette("#FFEB3B") },
+  { id: "sh", label: "sh", palette: createPalette("#FF9800") },
+  { id: "ts", label: "ts", palette: createPalette("#4FC3F7") },
+  { id: "z", label: "z", palette: createPalette("#81C784") },
+  { id: "kh-ch", label: "kh/ch", palette: createPalette("#F06292", "#FFFFFF") },
+  { id: "k-q", label: "k/q", palette: createPalette("#9575CD", "#FFFFFF") },
+  { id: "g", label: "g", palette: createPalette("#4DB6AC") },
+  { id: "h", label: "h", palette: createPalette("#FFF176") },
+  { id: "d", label: "d", palette: createPalette("#E57373") },
+  { id: "t", label: "t", palette: createPalette("#64B5F6") },
+  { id: "n", label: "n", palette: createPalette("#AED581") },
+  { id: "m", label: "m", palette: createPalette("#F8BBD0") },
+  { id: "b", label: "b", palette: createPalette("#7986CB", "#FFFFFF") },
+  { id: "v", label: "v", palette: createPalette("#80CBC4") },
+  { id: "p", label: "p", palette: createPalette("#FFB74D") },
+  { id: "f", label: "f", palette: createPalette("#B39DDB") },
+  { id: "l", label: "l", palette: createPalette("#B3E5FC") },
+  { id: "r", label: "r", palette: createPalette("#C5CAE9") },
+  { id: "y", label: "y", palette: createPalette("#DCEDC8") },
+];
+
+export const LETTER_CHIPS: LetterChip[] = [
+  { id: "aleph", label: "א", palette: createPalette("#FFECB3") },
+  { id: "bet", label: "ב", palette: createPalette("#C5CAE9") },
+  { id: "gimel", label: "ג", palette: createPalette("#B2DFDB") },
+  { id: "dalet", label: "ד", palette: createPalette("#FFCDD2") },
+  { id: "he", label: "ה", palette: createPalette("#FFF9C4") },
+  { id: "vav", label: "ו", palette: createPalette("#B3E5FC") },
+  { id: "zayin", label: "ז", palette: createPalette("#C8E6C9") },
+  { id: "het", label: "ח", palette: createPalette("#F8BBD0") },
+  { id: "tet", label: "ט", palette: createPalette("#E1BEE7") },
+  { id: "yod", label: "י", palette: createPalette("#DCEDC8") },
+  { id: "kaf", label: "כ", palette: createPalette("#D1C4E9") },
+  { id: "final-kaf", label: "ך", palette: createPalette("#EDE7F6") },
+  { id: "lamed", label: "ל", palette: createPalette("#BBDEFB") },
+  { id: "mem", label: "מ", palette: createPalette("#F0F4C3") },
+  { id: "final-mem", label: "ם", palette: createPalette("#F7FAE6") },
+  { id: "nun", label: "נ", palette: createPalette("#FFE0B2") },
+  { id: "final-nun", label: "ן", palette: createPalette("#FFF3E0") },
+  { id: "samekh", label: "ס", palette: createPalette("#FFEB3B") },
+  { id: "ayin", label: "ע", palette: createPalette("#CFD8DC") },
+  { id: "pe", label: "פ", palette: createPalette("#FFD54F") },
+  { id: "tsadi", label: "צ", palette: createPalette("#4FC3F7") },
+  { id: "final-tsadi", label: "ץ", palette: createPalette("#B3E5FC") },
+  { id: "qof", label: "ק", palette: createPalette("#9575CD", "#FFFFFF") },
+  { id: "resh", label: "ר", palette: createPalette("#90A4AE") },
+  { id: "sin", label: "שׂ", palette: createPalette("#FFF176") },
+  { id: "shin", label: "שׁ", palette: createPalette("#FF9800") },
+  { id: "tav", label: "ת", palette: createPalette("#64B5F6") },
+];
+
+export const SOUND_CHIP_MAP = new Map(SOUND_CHIPS.map((chip) => [chip.id, chip]));
+export const LETTER_CHIP_MAP = new Map(LETTER_CHIPS.map((chip) => [chip.id, chip]));
+
+const transliterationPatterns: TransliterationPattern[] = [
+  { text: "kh", soundId: "kh-ch" },
+  { text: "ch", soundId: "kh-ch" },
+  { text: "sh", soundId: "sh" },
+  { text: "ts", soundId: "ts" },
+  { text: "q", soundId: "k-q" },
+  { text: "k", soundId: "k-q" },
+  { text: "s", soundId: "s" },
+  { text: "z", soundId: "z" },
+  { text: "g", soundId: "g" },
+  { text: "h", soundId: "h" },
+  { text: "d", soundId: "d" },
+  { text: "t", soundId: "t" },
+  { text: "n", soundId: "n" },
+  { text: "m", soundId: "m" },
+  { text: "b", soundId: "b" },
+  { text: "v", soundId: "v" },
+  { text: "p", soundId: "p" },
+  { text: "f", soundId: "f" },
+  { text: "l", soundId: "l" },
+  { text: "r", soundId: "r" },
+  { text: "y", soundId: "y" },
+];
+
+const COMBINING_MARK = /\p{M}/u;
+const HEBREW_LETTER = /\p{Script=Hebrew}/u;
+const DAGESH = "\u05BC";
+const SHIN_DOT = "\u05C1";
+const SIN_DOT = "\u05C2";
+
+const pushInlineSegment = (
+  segments: InlineTextSegment[],
+  text: string,
+  highlightId?: string,
+) => {
+  if (!text) {
+    return;
+  }
+
+  const previous = segments[segments.length - 1];
+  if (previous && previous.highlightId === highlightId) {
+    previous.text += text;
+    return;
+  }
+
+  segments.push({ text, highlightId });
+};
+
+const getHebrewClusterMetadata = (cluster: string): HebrewClusterMatch => {
+  const normalized = cluster.normalize("NFKD");
+  let base = "";
+  const marks = new Set<string>();
+
+  for (const char of normalized) {
+    if (!base && HEBREW_LETTER.test(char)) {
+      base = char;
+      continue;
+    }
+
+    if (COMBINING_MARK.test(char)) {
+      marks.add(char);
+    }
+  }
+
+  const hasDagesh = marks.has(DAGESH);
+  const hasShinDot = marks.has(SHIN_DOT);
+  const hasSinDot = marks.has(SIN_DOT);
+
+  switch (base) {
+    case "א":
+      return { text: cluster, letterId: "aleph", soundIds: [] };
+    case "ב":
+      return {
+        text: cluster,
+        letterId: "bet",
+        soundIds: [hasDagesh ? "b" : "v"],
+      };
+    case "ג":
+      return { text: cluster, letterId: "gimel", soundIds: ["g"] };
+    case "ד":
+      return { text: cluster, letterId: "dalet", soundIds: ["d"] };
+    case "ה":
+      return { text: cluster, letterId: "he", soundIds: ["h"] };
+    case "ו":
+      return { text: cluster, letterId: "vav", soundIds: ["v"] };
+    case "ז":
+      return { text: cluster, letterId: "zayin", soundIds: ["z"] };
+    case "ח":
+      return { text: cluster, letterId: "het", soundIds: ["kh-ch"] };
+    case "ט":
+      return { text: cluster, letterId: "tet", soundIds: ["t"] };
+    case "י":
+      return { text: cluster, letterId: "yod", soundIds: ["y"] };
+    case "כ":
+      return {
+        text: cluster,
+        letterId: "kaf",
+        soundIds: [hasDagesh ? "k-q" : "kh-ch"],
+      };
+    case "ך":
+      return {
+        text: cluster,
+        letterId: "final-kaf",
+        soundIds: [hasDagesh ? "k-q" : "kh-ch"],
+      };
+    case "ל":
+      return { text: cluster, letterId: "lamed", soundIds: ["l"] };
+    case "מ":
+      return { text: cluster, letterId: "mem", soundIds: ["m"] };
+    case "ם":
+      return { text: cluster, letterId: "final-mem", soundIds: ["m"] };
+    case "נ":
+      return { text: cluster, letterId: "nun", soundIds: ["n"] };
+    case "ן":
+      return { text: cluster, letterId: "final-nun", soundIds: ["n"] };
+    case "ס":
+      return { text: cluster, letterId: "samekh", soundIds: ["s"] };
+    case "ע":
+      return { text: cluster, letterId: "ayin", soundIds: [] };
+    case "פ":
+      return {
+        text: cluster,
+        letterId: "pe",
+        soundIds: [hasDagesh ? "p" : "f"],
+      };
+    case "צ":
+      return { text: cluster, letterId: "tsadi", soundIds: ["ts"] };
+    case "ץ":
+      return { text: cluster, letterId: "final-tsadi", soundIds: ["ts"] };
+    case "ק":
+      return { text: cluster, letterId: "qof", soundIds: ["k-q"] };
+    case "ר":
+      return { text: cluster, letterId: "resh", soundIds: ["r"] };
+    case "ש":
+      return {
+        text: cluster,
+        letterId: hasSinDot ? "sin" : "shin",
+        soundIds: [hasSinDot ? "s" : "sh"],
+      };
+    case "ת":
+      return { text: cluster, letterId: "tav", soundIds: ["t"] };
+    default:
+      return { text: cluster, soundIds: [] };
+  }
+};
+
+export const splitTransliterationSegments = (text: string): InlineTextSegment[] => {
+  const segments: InlineTextSegment[] = [];
+  let index = 0;
+
+  while (index < text.length) {
+    const slice = text.slice(index);
+    const lowerSlice = slice.toLowerCase();
+    const match = transliterationPatterns.find((pattern) =>
+      lowerSlice.startsWith(pattern.text),
+    );
+
+    if (match) {
+      pushInlineSegment(
+        segments,
+        text.slice(index, index + match.text.length),
+        match.soundId,
+      );
+      index += match.text.length;
+      continue;
+    }
+
+    pushInlineSegment(segments, text[index]);
+    index += 1;
+  }
+
+  return segments;
+};
+
+export const splitHebrewClusters = (text: string): HebrewClusterMatch[] => {
+  const clusters: HebrewClusterMatch[] = [];
+  let currentCluster = "";
+
+  const flushCluster = () => {
+    if (!currentCluster) {
+      return;
+    }
+    clusters.push(getHebrewClusterMetadata(currentCluster));
+    currentCluster = "";
+  };
+
+  for (const char of text) {
+    if (!currentCluster) {
+      currentCluster = char;
+      continue;
+    }
+
+    if (COMBINING_MARK.test(char)) {
+      currentCluster += char;
+      continue;
+    }
+
+    flushCluster();
+    currentCluster = char;
+  }
+
+  flushCluster();
+  return clusters;
+};
+
+export const countSoundOccurrences = (word: WordProps, soundId: string): number => {
+  const transliteration = word.wordInformation?.transliteration ?? "";
+  if (transliteration) {
+    return splitTransliterationSegments(transliteration).filter(
+      (segment) => segment.highlightId === soundId,
+    ).length;
+  }
+
+  const hebrew = word.wordInformation?.hebrew || word.wlcWord || "";
+  return splitHebrewClusters(hebrew).filter((cluster) =>
+    cluster.soundIds.includes(soundId),
+  ).length;
+};
+
+export const countLetterOccurrences = (word: WordProps, letterId: string): number => {
+  const hebrew = word.wordInformation?.hebrew || word.wlcWord || "";
+  return splitHebrewClusters(hebrew).filter(
+    (cluster) => cluster.letterId === letterId,
+  ).length;
+};
+
+export const wordContainsSound = (word: WordProps, soundId: string): boolean =>
+  countSoundOccurrences(word, soundId) > 0;
+
+export const wordContainsLetter = (word: WordProps, letterId: string): boolean =>
+  countLetterOccurrences(word, letterId) > 0;
+
+export const buildHighlightedTransliterationSegments = (
+  text: string,
+  selectedSoundIds: Set<string>,
+): InlineTextSegment[] =>
+  splitTransliterationSegments(text).map((segment) =>
+    segment.highlightId && selectedSoundIds.has(segment.highlightId)
+      ? segment
+      : { text: segment.text },
+  );
+
+export const buildHighlightedHebrewSegments = (
+  text: string,
+  selectedSoundIds: Set<string>,
+  selectedLetterIds: Set<string>,
+): InlineTextSegment[] => {
+  const segments: InlineTextSegment[] = [];
+
+  splitHebrewClusters(text).forEach((cluster) => {
+    const soundMatch = cluster.soundIds.find((soundId) => selectedSoundIds.has(soundId));
+    if (soundMatch) {
+      pushInlineSegment(segments, cluster.text, soundMatch);
+      return;
+    }
+
+    if (cluster.letterId && selectedLetterIds.has(cluster.letterId)) {
+      pushInlineSegment(segments, cluster.text, cluster.letterId);
+      return;
+    }
+
+    pushInlineSegment(segments, cluster.text);
+  });
+
+  return segments;
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,7 +27,8 @@ export enum LanguageMode {
 
 export enum NonEnglishDisplayMode {
     Hebrew,
-    Transliteration
+    Transliteration,
+    HebrewTransliteration
 }
 
 export interface ColorPickerProps {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,11 @@ export enum LanguageMode {
     Hebrew
 }
 
+export enum NonEnglishDisplayMode {
+    Hebrew,
+    Transliteration
+}
+
 export interface ColorPickerProps {
     colorAction: ColorActionType,
     setSelectedColor: (arg: string) => void;

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,131 +2,92 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-25ztgh1ri-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-j7fos0p3h-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NTg2MjgsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJSU91Z2Q3Vm90N0JBbU5aSEFGYmpMdHhNIiwic3QiOiJzaWduX2luX3Rva2VuIn0.J2NZulXECU0ReuJynLtgALCDLVlFV_sKjadJD1jNyqfWCeh5SrPpCy0r0FxJBa6OS1ZClOr8Y_xpYh3mw7pXejXBv2YnHUx1j5puSeBdRrJQ2FGAHOGg7ZwjRgTNUG0GSw087vpbEctTxhDuwiSxu_nrfjiaGMMToEpIgkMtg6ZZ-cCDMdLmPkU6irYjAPygWYronnkeZ0ABTCE8nvioOftecjuEyXGFhQiX0FmOjJL9-RocSksmiG2XLJZxrH3xjJFjisq9ydm_Xrq1no6KHHwfgS4_3JQvh10zyyTtytRwFXt3149kQbXJqQPedau1vhsPhY1ezXMEQEf30m4sVg";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjEyNzQsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJTmxSek9xR3dwUkQ1NUdyZWZZbkUyMzA3Iiwic3QiOiJzaWduX2luX3Rva2VuIn0.dLNm6cB_S3QwHh3beMauPGjfuHAPR38Pap4ntu2h7jkfVabbE42XqZSV1S3jq8MdouQ3U6ShAKQBjL8a_SC2nhV3BaQDT6ECkzTL_b-JohJUjNEgp-qCSb3m_hYLd3TKqQ-rnUFv8qgjbHdx6-ScJU8Bxee6a4Sicbx-F5mf3sNXURFP2iIJ9QRuC7nEqi-O309FtHzHwNdmQ1IlSI91VilyNZo6NbOjXr8SheEwyfh4M_A2rTnrpdoUsA_SEOOTwh9kAWKrLvAWlFdLpo_J1NhEJwx2eXyI1lu9LC088tZlquzXlOBm8Rb-Nim_qTd9lBmja-C3ygfOSrYaZcodIQ";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
 
-test.use({ viewport: { width: 1600, height: 900 } });
+test.use({ viewport: { width: 1440, height: 810 } });
 
-test("capture all dropdown states + features", async ({ page }) => {
+test("match PDF exactly", async ({ page }) => {
   test.setTimeout(180_000);
-  
-  // Login
   await page.goto(baseUrl + "/sign-in?__clerk_ticket=" + token);
   await page.waitForTimeout(8000);
-
-  // Load Psalm 23
   for (let i = 0; i < 5; i++) {
     await page.goto(baseUrl + "/study/" + studyId + "/edit?t=" + Date.now(), { waitUntil: "domcontentloaded", timeout: 20_000 }).catch(() => {});
     await page.waitForTimeout(5000);
     if (!(await page.locator("text=Application error").isVisible().catch(() => false))) {
-      const ok = await page.locator('label[for="toggleLang"]').isVisible().catch(() => false);
-      if (ok) { console.log("✅ Study loaded"); break; }
+      if (await page.locator('label[for="toggleLang"]').isVisible().catch(() => false)) { console.log("✅ Loaded"); break; }
     }
-    console.log("retry " + (i+1));
-    await page.waitForTimeout(3000);
-  }
-  
-  await page.evaluate(() => { (document.body.style as any).zoom = "0.85"; });
-  await page.waitForTimeout(1000);
-
-  // === DROPDOWN SCREENSHOTS (matching PDF pages 2-5 exactly) ===
-  
-  // 1. A mode — click A, show chevron, open dropdown showing "English Gloss" (PDF Page 3)
-  await page.locator('label[for="toggleLang"] span').first().click(); // click A
-  await page.waitForTimeout(800);
-  await snap(page, "01-A-mode-english");
-  // Open A dropdown
-  const chevA = page.locator('label[for="toggleLang"] svg').first();
-  if (await chevA.isVisible().catch(() => false)) {
-    await chevA.click();
-    await page.waitForTimeout(600);
-    await snap(page, "02-A-dropdown-open");  // Shows "English Gloss" 
-    // Close
-    await page.mouse.click(400, 400);
-    await page.waitForTimeout(400);
+    console.log("retry " + (i+1)); await page.waitForTimeout(3000);
   }
 
-  // 2. Aא mode — click Aא, open dropdown showing 3 options (PDF Page 4)
+  // ZOOM: Click the scale dropdown trigger, then click "200%" preset
+  const scaleTrigger = page.locator('#scaleInput').locator('..');
+  await scaleTrigger.click();
+  await page.waitForTimeout(500);
+  // Click "200%" in the dropdown list
+  const zoom200 = page.locator('li:has-text("200%")');
+  if (await zoom200.isVisible().catch(() => false)) {
+    await zoom200.click();
+    await page.waitForTimeout(2000);
+    console.log("✅ Zoomed to 200%");
+  } else {
+    console.log("⚠️ 200% option not found, trying list items...");
+    const lis = page.locator('li');
+    const liCount = await lis.count();
+    for (let i = 0; i < liCount; i++) {
+      const text = await lis.nth(i).innerText();
+      console.log("  li[" + i + "]: " + text.trim());
+      if (text.trim() === "200%") {
+        await lis.nth(i).click();
+        await page.waitForTimeout(2000);
+        console.log("✅ Clicked 200%");
+        break;
+      }
+    }
+  }
+  const zoomVal = await page.locator('#scaleInput').inputValue();
+  console.log("Zoom now: " + zoomVal);
+
+  // ================================================================
+  // PAGE 4
+  // ================================================================
   await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
-  await page.waitForTimeout(1000);
-  await snap(page, "03-Ax-mode-parallel");
-  // Open Aא dropdown
-  const chevAx = page.locator('label[for="toggleLang"] svg').first();
-  if (await chevAx.isVisible().catch(() => false)) {
-    await chevAx.click();
-    await page.waitForTimeout(600);
-    await snap(page, "04-Ax-dropdown-3-options");  // Shows 3 options!
-    // Select "English Gloss / Hebrew Transliteration"
-    await page.locator('.shadow-lg button:has-text("Hebrew Transliteration")').last().click();
-    await page.waitForTimeout(1200);
-    await snap(page, "05-transliteration-active");
-    // Back to Hebrew OHB
-    const chevAx2 = page.locator('label[for="toggleLang"] svg').first();
-    if (await chevAx2.isVisible().catch(() => false)) {
-      await chevAx2.click();
-      await page.waitForTimeout(500);
-      await page.locator('.shadow-lg button:has-text("Hebrew OHB")').click();
-      await page.waitForTimeout(800);
-    }
-  }
+  await page.waitForTimeout(800);
+  let chev = page.locator('label[for="toggleLang"] svg').first();
+  if (await chev.isVisible().catch(() => false)) { await chev.click(); await page.waitForTimeout(500); await page.locator('.shadow-lg button:has-text("Hebrew Transliteration")').last().click(); await page.waitForTimeout(1500); }
+  chev = page.locator('label[for="toggleLang"] svg').first();
+  if (await chev.isVisible().catch(() => false)) { await chev.click(); await page.waitForTimeout(500); }
+  await snap(page, "01-page4-match");
+  await page.mouse.click(100, 400); await page.waitForTimeout(300);
+  await snap(page, "02-transliteration-clean");
 
-  // 3. א mode — click א, open dropdown showing 2 options (PDF Page 5)
+  // PAGE 5
   await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
-  await page.waitForTimeout(1000);
-  await snap(page, "06-x-mode-hebrew");
-  const chevX = page.locator('label[for="toggleLang"] svg').first();
-  if (await chevX.isVisible().catch(() => false)) {
-    await chevX.click();
-    await page.waitForTimeout(600);
-    await snap(page, "07-x-dropdown-2-options");  // Shows "Hebrew OHB" + "Transliteration"
-    // Close
-    await page.mouse.click(400, 400);
-    await page.waitForTimeout(400);
-  }
-
-  // Back to parallel for Sounds features
-  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
   await page.waitForTimeout(800);
+  chev = page.locator('label[for="toggleLang"] svg').first();
+  if (await chev.isVisible().catch(() => false)) { await chev.click(); await page.waitForTimeout(500); const t=page.locator('.shadow-lg button:has-text("Transliteration")'); if(await t.isVisible().catch(()=>false)){await t.click();await page.waitForTimeout(1200);} chev=page.locator('label[for="toggleLang"] svg').first(); if(await chev.isVisible().catch(()=>false)){await chev.click();await page.waitForTimeout(500);} }
+  await snap(page, "03-page5-match");
+  await page.mouse.click(100, 400); await page.waitForTimeout(300);
+  await snap(page, "04-page5-transliteration");
 
-  // === SOUND DISTRIBUTION SCREENSHOTS ===
-  const sb = page.getByRole("button", { name: "Sounds" });
-  if (await sb.isVisible().catch(() => false)) {
-    await sb.click({ force: true }); await page.waitForTimeout(1500);
-    await snap(page, "08-sounds-panel");
-    
-    // Tooltip
-    const tip = page.locator("span[title]").filter({ hasText: "i" }).first();
-    if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(800); await snap(page, "09-tooltip"); await page.mouse.move(0,0); await page.waitForTimeout(300); }
-    
-    // sh chip + highlight
-    try { await chip(page,"sh"); await snap(page,"10-sh-selected");
-      const h=page.getByRole("button",{name:"Smart Highlight"}).first();
-      if(await h.isVisible().catch(()=>false)){await h.click({force:true});await page.waitForTimeout(1200);await snap(page,"11-smart-highlight");
-      const c=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c.isVisible().catch(()=>false)){await c.click();await page.waitForTimeout(600);}}
-      await chip(page,"sh");} catch(e){console.log(e);}
-    
-    // Multi
-    try { await chip(page,"sh"); await chip(page,"m");
-      const h2=page.getByRole("button",{name:"Smart Highlight"}).first();
-      if(await h2.isVisible().catch(()=>false)){await h2.click({force:true});await page.waitForTimeout(1200);await snap(page,"12-multi-highlight");
-      const c2=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c2.isVisible().catch(()=>false)){await c2.click();await page.waitForTimeout(500);}
-      }await chip(page,"sh");await chip(page,"m");} catch{}
-    
-    // Letters
-    const lb=page.getByRole("button",{name:/Hebrew Letter/i});
-    if(await lb.isVisible().catch(()=>false)){await lb.click();await page.waitForTimeout(1500);await snap(page,"13-letter-panel");
-      try{await chip(page,"ל");const h3=page.getByRole("button",{name:"Smart Highlight"}).first();
-      if(await h3.isVisible().catch(()=>false)){await h3.click({force:true});await page.waitForTimeout(1200);await snap(page,"14-letter-highlight");
-      const c3=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c3.isVisible().catch(()=>false)){await c3.click();await page.waitForTimeout(500);}}}catch{}}
-    
-    // Disclaimer
-    const acc=page.locator(".accordion").first();
-    if(await acc.isVisible().catch(()=>false)){await acc.evaluate(el=>el.scrollTop=el.scrollHeight);await page.waitForTimeout(500);await snap(page,"15-disclaimer");}
+  // Sounds
+  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click(); await page.waitForTimeout(600);
+  chev=page.locator('label[for="toggleLang"] svg').first(); if(await chev.isVisible().catch(()=>false)){await chev.click();await page.waitForTimeout(500);await page.locator('.shadow-lg button:has-text("Hebrew Transliteration")').last().click();await page.waitForTimeout(800);}
+  const sb=page.getByRole("button",{name:"Sounds"});
+  if(await sb.isVisible().catch(()=>false)){
+    await sb.click({force:true});await page.waitForTimeout(1500);await snap(page,"05-sounds-panel");
+    const tip=page.locator("span[title]").filter({hasText:"i"}).first();
+    if(await tip.isVisible().catch(()=>false)){await tip.hover();await page.waitForTimeout(800);await snap(page,"06-tooltip");await page.mouse.move(0,0);await page.waitForTimeout(300);}
+    try{await chip(page,"sh");const h=page.getByRole("button",{name:"Smart Highlight"}).first();if(await h.isVisible().catch(()=>false)){await h.click({force:true});await page.waitForTimeout(1200);await snap(page,"07-smart-highlight");const c=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c.isVisible().catch(()=>false)){await c.click();await page.waitForTimeout(600);}}await chip(page,"sh");}catch(e){console.log(e);}
+    chev=page.locator('label[for="toggleLang"] svg').first();if(await chev.isVisible().catch(()=>false)){await chev.click();await page.waitForTimeout(500);await page.locator('.shadow-lg button:has-text("Hebrew OHB")').click();await page.waitForTimeout(800);}
+    try{await chip(page,"sh");const h2=page.getByRole("button",{name:"Smart Highlight"}).first();if(await h2.isVisible().catch(()=>false)){await h2.click({force:true});await page.waitForTimeout(1200);await snap(page,"08-hebrew-highlight");const c2=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c2.isVisible().catch(()=>false)){await c2.click();await page.waitForTimeout(500);}}}catch{}
+    const lb=page.getByRole("button",{name:/Hebrew Letter/i});if(await lb.isVisible().catch(()=>false)){await lb.click();await page.waitForTimeout(1500);await snap(page,"09-letter-panel");try{await chip(page,"ל");const h3=page.getByRole("button",{name:"Smart Highlight"}).first();if(await h3.isVisible().catch(()=>false)){await h3.click({force:true});await page.waitForTimeout(1200);await snap(page,"10-letter-highlight");}}catch{}}
+    const acc=page.locator(".accordion").first();if(await acc.isVisible().catch(()=>false)){await acc.evaluate(el=>el.scrollTop=el.scrollHeight);await page.waitForTimeout(500);await snap(page,"11-disclaimer");}
   }
-  
-  console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length + " screenshots");
+  console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length);
 });
+

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-itxikw7rl-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-i8z5odh4i-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjQxOTAsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJVGZ2ak9OQWpzNkNJcmpJQXJrSWlaUjBNIiwic3QiOiJzaWduX2luX3Rva2VuIn0.YAVOqVQPjTlObhzBtYmPxgvm6Vv4Zc-jwEMUjG_cJvg3DKWN0MeFP752WNqLpJrj0wmW6ZIsMwRziPUDwyEHA6iVW0wLM7qxcucbVW_xCmZNejGQFv_F5-mflTOLTBQH_YUsfaHiUkVfS8411uPHn66eejqkvCTzUJDyXt2VIeBnZ1J30acrp6WeimDF4ijxbBj5D7dnfbKy0itUY8JQ9a_M3ru5S1xbSd4G38iCFEOiSd-ZtS32eunbz-oTleYZ2whzRG6gfeVzWrVbtDRMv1JjNe5J8AvVzVFLkGKj2H7azUk1ZNnO5q0QAUvGO56Sp1lEV4ojv4cWRuAIVSP9vQ";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3MDQ2ODcsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NKbmwzamU3aUpsVXFScmNPeGx6S3k4aTdwIiwic3QiOiJzaWduX2luX3Rva2VuIn0.SVNoCWKlpmPCZvrmXEo7JgyygRNnVaZQrhs9FB1_DZNmTlF5Q6HHY6qx9-PQ4153FRgX0ww5lWwa8dG-3Usgjz25bnzWD9zZ7ltuZdyixlvqZHw4WpPKeyB2bNdHEmow_8o9L61kEYLqwmEqOW8S-zDV7yT3-TAQ9Gc7raHfNIHqH5IHl2ohRypCt76iGHcC8CXSFdY5pSUkXZLKHjKp_N-yqOMUVk3yhee5EasW1JqQdguVTZu2CwvcUe-7yAsd5kRyZdLDLzkfeyQx1Jxi9siyRo4V6Zx8Mg3YF8myy7Sbw-FS1UiXiYC8zF8J2alIBfwN38ES-MTGGTsnEhLYKA";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -12,10 +12,9 @@ const openDD = async (p: Page) => { const c=p.locator('label[for="toggleLang"] s
 const pickMode = async (p: Page, l: string) => { await openDD(p); await p.locator('.shadow-lg button:has-text("'+l+'")').last().click(); await p.waitForTimeout(1200); };
 const zoom = async (p: Page, pct: string) => { const t=p.locator('#scaleInput').locator('..'); await t.click(); await p.waitForTimeout(500); const o=p.locator('li:has-text("'+pct+'")'); if(await o.isVisible().catch(()=>false)){await o.click();await p.waitForTimeout(1500);} };
 
-// Use WIDER viewport so 200% zoom fits with sidebar
 test.use({ viewport: { width: 1920, height: 1080 } });
 
-test("match PDF at 200%", async ({ page }) => {
+test("final capture", async ({ page }) => {
   test.setTimeout(180_000);
   await page.goto(baseUrl + "/sign-in?__clerk_ticket=" + token);
   await page.waitForTimeout(8000);
@@ -28,11 +27,11 @@ test("match PDF at 200%", async ({ page }) => {
     console.log("retry " + (i+1)); await page.waitForTimeout(3000);
   }
 
-  // Aא parallel mode for everything
+  // ================================================================
+  // PAGES 4-5: Aא parallel + transliteration at 200% zoom (dropdown views)
+  // ================================================================
   await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
   await page.waitForTimeout(800);
-
-  // PAGE 4: 200% + transliteration + dropdown open
   await zoom(page, "200%");
   await pickMode(page, "Hebrew Transliteration");
   await openDD(page);
@@ -40,21 +39,25 @@ test("match PDF at 200%", async ({ page }) => {
   await page.mouse.click(100, 400); await page.waitForTimeout(300);
   await snap(page, "02-page5-transliteration");
 
-  // PAGES 7-13: Open Sounds panel — stay at 200%
+  // ================================================================
+  // PAGES 7-13: Aא parallel + transliteration at 100% zoom (sidebar views)
+  // 100% so passage + English + sidebar all fit
+  // ================================================================
+  await zoom(page, "100%");
   const sb = page.getByRole("button", { name: "Sounds" });
   await sb.click({ force: true }); await page.waitForTimeout(1500);
   await snap(page, "03-page7-sounds-panel");
 
-  // PAGE 11: s/sh/ts selected, Smart Highlight NOT yet clicked (button blue)
+  // PAGE 11: Select s/sh/ts, capture BEFORE clicking Smart Highlight
   await chip(page, "s"); await chip(page, "sh"); await chip(page, "ts");
   await snap(page, "04-page11-chips-selected");
 
-  // Click Smart Highlight — highlights appear
+  // Click Smart Highlight — highlights appear in passage
   const hlBtn = page.getByRole("button", { name: "Smart Highlight" }).first();
   if (await hlBtn.isVisible().catch(() => false)) { await hlBtn.click({ force: true }); await page.waitForTimeout(1500); }
   await snap(page, "05-page11-highlight-on");
 
-  // PAGE 12: Switch to Hebrew OHB (still parallel)
+  // PAGE 12: Switch to Hebrew OHB — Hebrew letters get highlighted
   await pickMode(page, "Hebrew OHB");
   await page.waitForTimeout(1000);
   await snap(page, "06-page12-hebrew-highlight");
@@ -69,7 +72,9 @@ test("match PDF at 200%", async ({ page }) => {
   const tip = page.locator("span[title]").filter({ hasText: "i" }).first();
   if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(1000); await snap(page, "07-page13-tooltip"); await page.mouse.move(0, 0); await page.waitForTimeout(300); }
 
-  // PAGES 16-17: Letter Distribution (Hebrew OHB)
+  // ================================================================
+  // PAGES 16-17: Letter Distribution at 100% with Hebrew OHB
+  // ================================================================
   await pickMode(page, "Hebrew OHB");
   const lb = page.getByRole("button", { name: /Hebrew Letter/i });
   if (await lb.isVisible().catch(() => false)) {
@@ -83,5 +88,3 @@ test("match PDF at 200%", async ({ page }) => {
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
-
-

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-fne0uwjhk-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-t2j8mnqnr-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjIzMzgsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJUHY5ams5UXpXdG1odm1ucHNMZmI4bktaIiwic3QiOiJzaWduX2luX3Rva2VuIn0.koxampKKe3QQMuHdt56AyJ2uukacsQ3Ifqtj1D3JWHKwuTAv0mTvo8ZOX7ZuzVL7Wew9YxywZiOZ-hq1Wymsfz-2OgcgcJyk9PE37KigTbvD7nKusilnIMNx0t_hX-jOqhcITdRYgKDqfDzBYk6uNtULrkO5aQBDXbm5Lw37YzDqHU-N1jLK9W_zhpnf2x33Z4EkC1br37IQMvXOLjqPmU4SIIFzr1KOhP09ikXXzjqsFwZWr3GCKNQT2YABGF6sMd86OuVB-O9IV-0RQmQccWO8rOcKFAgRRpFeLPD9FIh87kHqQzX-P_LaBq-x3eiGd1uE8r-HzLd7t_xaK7qZcg";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjI3NDksImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJUWtsTWtiaG9pa2tOaFlja01XT2RFZXdSIiwic3QiOiJzaWduX2luX3Rva2VuIn0.afkF21pwG10eqQKipc2iG7BsWsPyXtWNrfz7B6qP83-lDGwObMyzl2wHNMhXbISaTr-bcEJXvQBDmBztda2kKeH8IoEVUL2Dtk0brRszWTOHjU1crU26c5sWR874-RlIituxYkmqvFtyS1_cWkaGyKPeMtVmk362ALbb5eUl6EIDLAzXlQY6YQDyTMO1HJbwkcIdWTLd_6zkN-cKxK11aDocVyg7jPoD4DS19Mf5U6pOI57qIg2nFg3xaocRstaUaSuIQukuAeG_91H4PQKj7KAEZrp3ItyzqL05xkLR8iafDIUOycfS4MiLpG3xqgLxLNpufZZR6uiJY62fwA5Cdw";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -106,3 +106,5 @@ test("final capture", async ({ page }) => {
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
+
+

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-kidcw8ic4-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-fugqxk5ml-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg1NjQ0MDYsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NGRFFKQmt5TkVENExLSkxEN0NlWlNhb21zIiwic3QiOiJzaWduX2luX3Rva2VuIn0.ZQmqwy_HSyfp8mnNq1yhw9cH6TLVd-qWLjlEJ_e9T-PqgjnZylj57iuSaha2TOLrL-4A4Ft_LtkbPai6BLmTRggRUeWzoCu2DoBz35RGpt3Tx0p2q76Vk40g79CoLjK52OeQHvuyog4T-q1_yQBzgJ_rCWKit3RgYkKlJPe0r4Njs4akohJORyzb_9R8Lqykhjqz76pX5NGS5VrSXlSFYlgS5dZccLoGWlfQ_TFUJOhikX9tbWUFlrmb1sJ7Mg3-p01ivlxbiDg_9VYhdtbBHM8k11eym8mBLG_PPiy00d4LT5d8D57ffLDO6TLn5jV4e_0LV3CRVNEWf_AFKXAhhA";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg1NjQ3MDcsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NGRTI0VWk1a1J6NFJxTVd4QU5JYW9pUHJQIiwic3QiOiJzaWduX2luX3Rva2VuIn0.VuLXssVmHf_0nQIVr853m2P4kzBF0wRxVOn_ekiFHTcAM-eHamh4E1KiSNAfIzKerplXtO9M4dc8ELceEbzlTPVH-pxPRMHrfDOdMIJM24_tBdnqaxAE8K2MMucg2CSo4h7wVXVkaPMu70QdJeno_M0mOBmKDQIQsNmNNUoOzjeabOPa8peoUepbwlf-A5m35r0bHwtvJtcQQr57RGjh1WsrarKewlPj4fJRNvoRL2_QVW_KTqyttCNwARIBkxOVJflNGMB8hfyWSb5OMDQkJYugYed_TaAQJiIvSgsRmwZEYv-WtGBNDN7Xe1sh1a6-ynIeaWJ2nvYNYp_xrk5imQ";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -66,3 +66,4 @@ test("capture Psalm 23", async ({ page }) => {
   }
   console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length);
 });
+

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,16 +2,19 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-j7fos0p3h-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-fne0uwjhk-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjEyNzQsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJTmxSek9xR3dwUkQ1NUdyZWZZbkUyMzA3Iiwic3QiOiJzaWduX2luX3Rva2VuIn0.dLNm6cB_S3QwHh3beMauPGjfuHAPR38Pap4ntu2h7jkfVabbE42XqZSV1S3jq8MdouQ3U6ShAKQBjL8a_SC2nhV3BaQDT6ECkzTL_b-JohJUjNEgp-qCSb3m_hYLd3TKqQ-rnUFv8qgjbHdx6-ScJU8Bxee6a4Sicbx-F5mf3sNXURFP2iIJ9QRuC7nEqi-O309FtHzHwNdmQ1IlSI91VilyNZo6NbOjXr8SheEwyfh4M_A2rTnrpdoUsA_SEOOTwh9kAWKrLvAWlFdLpo_J1NhEJwx2eXyI1lu9LC088tZlquzXlOBm8Rb-Nim_qTd9lBmja-C3ygfOSrYaZcodIQ";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjIzMzgsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJUHY5ams5UXpXdG1odm1ucHNMZmI4bktaIiwic3QiOiJzaWduX2luX3Rva2VuIn0.koxampKKe3QQMuHdt56AyJ2uukacsQ3Ifqtj1D3JWHKwuTAv0mTvo8ZOX7ZuzVL7Wew9YxywZiOZ-hq1Wymsfz-2OgcgcJyk9PE37KigTbvD7nKusilnIMNx0t_hX-jOqhcITdRYgKDqfDzBYk6uNtULrkO5aQBDXbm5Lw37YzDqHU-N1jLK9W_zhpnf2x33Z4EkC1br37IQMvXOLjqPmU4SIIFzr1KOhP09ikXXzjqsFwZWr3GCKNQT2YABGF6sMd86OuVB-O9IV-0RQmQccWO8rOcKFAgRRpFeLPD9FIh87kHqQzX-P_LaBq-x3eiGd1uE8r-HzLd7t_xaK7qZcg";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
+const openDD = async (p: Page) => { const c=p.locator('label[for="toggleLang"] svg').first(); if(await c.isVisible().catch(()=>false)){await c.click();await p.waitForTimeout(500);} };
+const pickMode = async (p: Page, l: string) => { await openDD(p); await p.locator('.shadow-lg button:has-text("'+l+'")').last().click(); await p.waitForTimeout(1200); };
+const setZoom = async (p: Page, pct: string) => { const t=p.locator('#scaleInput').locator('..'); await t.click(); await p.waitForTimeout(500); const o=p.locator('li:has-text("'+pct+'")'); if(await o.isVisible().catch(()=>false)){await o.click();await page.waitForTimeout(1500);} };
 
 test.use({ viewport: { width: 1440, height: 810 } });
 
-test("match PDF exactly", async ({ page }) => {
+test("final capture", async ({ page }) => {
   test.setTimeout(180_000);
   await page.goto(baseUrl + "/sign-in?__clerk_ticket=" + token);
   await page.waitForTimeout(8000);
@@ -24,70 +27,82 @@ test("match PDF exactly", async ({ page }) => {
     console.log("retry " + (i+1)); await page.waitForTimeout(3000);
   }
 
-  // ZOOM: Click the scale dropdown trigger, then click "200%" preset
-  const scaleTrigger = page.locator('#scaleInput').locator('..');
-  await scaleTrigger.click();
-  await page.waitForTimeout(500);
-  // Click "200%" in the dropdown list
-  const zoom200 = page.locator('li:has-text("200%")');
-  if (await zoom200.isVisible().catch(() => false)) {
-    await zoom200.click();
-    await page.waitForTimeout(2000);
-    console.log("✅ Zoomed to 200%");
-  } else {
-    console.log("⚠️ 200% option not found, trying list items...");
-    const lis = page.locator('li');
-    const liCount = await lis.count();
-    for (let i = 0; i < liCount; i++) {
-      const text = await lis.nth(i).innerText();
-      console.log("  li[" + i + "]: " + text.trim());
-      if (text.trim() === "200%") {
-        await lis.nth(i).click();
-        await page.waitForTimeout(2000);
-        console.log("✅ Clicked 200%");
-        break;
-      }
-    }
-  }
-  const zoomVal = await page.locator('#scaleInput').inputValue();
-  console.log("Zoom now: " + zoomVal);
+  // Helper to set zoom via dropdown
+  const zoom = async (pct: string) => {
+    const t = page.locator('#scaleInput').locator('..');
+    await t.click(); await page.waitForTimeout(500);
+    const o = page.locator('li:has-text("' + pct + '")');
+    if (await o.isVisible().catch(() => false)) { await o.click(); await page.waitForTimeout(1500); }
+  };
 
   // ================================================================
-  // PAGE 4
+  // PAGES 4-5: Dropdown views at 200% (no sidebar, full passage)
   // ================================================================
+  await zoom("200%");
+
+  // Page 4: Aא parallel + transliteration
   await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
   await page.waitForTimeout(800);
-  let chev = page.locator('label[for="toggleLang"] svg').first();
-  if (await chev.isVisible().catch(() => false)) { await chev.click(); await page.waitForTimeout(500); await page.locator('.shadow-lg button:has-text("Hebrew Transliteration")').last().click(); await page.waitForTimeout(1500); }
-  chev = page.locator('label[for="toggleLang"] svg').first();
-  if (await chev.isVisible().catch(() => false)) { await chev.click(); await page.waitForTimeout(500); }
+  await pickMode(page, "Hebrew Transliteration");
+  await openDD(page);
   await snap(page, "01-page4-match");
   await page.mouse.click(100, 400); await page.waitForTimeout(300);
-  await snap(page, "02-transliteration-clean");
 
-  // PAGE 5
+  // Page 5: א transliteration + dropdown
   await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
   await page.waitForTimeout(800);
-  chev = page.locator('label[for="toggleLang"] svg').first();
-  if (await chev.isVisible().catch(() => false)) { await chev.click(); await page.waitForTimeout(500); const t=page.locator('.shadow-lg button:has-text("Transliteration")'); if(await t.isVisible().catch(()=>false)){await t.click();await page.waitForTimeout(1200);} chev=page.locator('label[for="toggleLang"] svg').first(); if(await chev.isVisible().catch(()=>false)){await chev.click();await page.waitForTimeout(500);} }
-  await snap(page, "03-page5-match");
+  await pickMode(page, "Transliteration");
+  await openDD(page);
+  await snap(page, "02-page5-match");
   await page.mouse.click(100, 400); await page.waitForTimeout(300);
-  await snap(page, "04-page5-transliteration");
 
-  // Sounds
-  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click(); await page.waitForTimeout(600);
-  chev=page.locator('label[for="toggleLang"] svg').first(); if(await chev.isVisible().catch(()=>false)){await chev.click();await page.waitForTimeout(500);await page.locator('.shadow-lg button:has-text("Hebrew Transliteration")').last().click();await page.waitForTimeout(800);}
-  const sb=page.getByRole("button",{name:"Sounds"});
-  if(await sb.isVisible().catch(()=>false)){
-    await sb.click({force:true});await page.waitForTimeout(1500);await snap(page,"05-sounds-panel");
-    const tip=page.locator("span[title]").filter({hasText:"i"}).first();
-    if(await tip.isVisible().catch(()=>false)){await tip.hover();await page.waitForTimeout(800);await snap(page,"06-tooltip");await page.mouse.move(0,0);await page.waitForTimeout(300);}
-    try{await chip(page,"sh");const h=page.getByRole("button",{name:"Smart Highlight"}).first();if(await h.isVisible().catch(()=>false)){await h.click({force:true});await page.waitForTimeout(1200);await snap(page,"07-smart-highlight");const c=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c.isVisible().catch(()=>false)){await c.click();await page.waitForTimeout(600);}}await chip(page,"sh");}catch(e){console.log(e);}
-    chev=page.locator('label[for="toggleLang"] svg').first();if(await chev.isVisible().catch(()=>false)){await chev.click();await page.waitForTimeout(500);await page.locator('.shadow-lg button:has-text("Hebrew OHB")').click();await page.waitForTimeout(800);}
-    try{await chip(page,"sh");const h2=page.getByRole("button",{name:"Smart Highlight"}).first();if(await h2.isVisible().catch(()=>false)){await h2.click({force:true});await page.waitForTimeout(1200);await snap(page,"08-hebrew-highlight");const c2=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c2.isVisible().catch(()=>false)){await c2.click();await page.waitForTimeout(500);}}}catch{}
-    const lb=page.getByRole("button",{name:/Hebrew Letter/i});if(await lb.isVisible().catch(()=>false)){await lb.click();await page.waitForTimeout(1500);await snap(page,"09-letter-panel");try{await chip(page,"ל");const h3=page.getByRole("button",{name:"Smart Highlight"}).first();if(await h3.isVisible().catch(()=>false)){await h3.click({force:true});await page.waitForTimeout(1200);await snap(page,"10-letter-highlight");}}catch{}}
-    const acc=page.locator(".accordion").first();if(await acc.isVisible().catch(()=>false)){await acc.evaluate(el=>el.scrollTop=el.scrollHeight);await page.waitForTimeout(500);await snap(page,"11-disclaimer");}
+  // ================================================================
+  // PAGES 7-13: Sounds features at 100% (sidebar + passage must fit)
+  // Stay in א transliteration mode (matching PDF page 11)
+  // ================================================================
+  await zoom("100%");
+  const sb = page.getByRole("button", { name: "Sounds" });
+  await sb.click({ force: true }); await page.waitForTimeout(1500);
+  await snap(page, "03-page7-sounds-panel");
+
+  // Page 11: s/sh/ts selected, Smart Highlight button visible (not yet clicked)
+  await chip(page, "s"); await chip(page, "sh"); await chip(page, "ts");
+  await snap(page, "04-page11-chips-selected");
+
+  // Click Smart Highlight
+  const hlBtn = page.getByRole("button", { name: "Smart Highlight" }).first();
+  if (await hlBtn.isVisible().catch(() => false)) { await hlBtn.click({ force: true }); await page.waitForTimeout(1500); }
+  await snap(page, "05-page11-highlight-on");
+
+  // Page 12: Switch to Hebrew OHB
+  await pickMode(page, "Hebrew OHB");
+  await page.waitForTimeout(1000);
+  await snap(page, "06-page12-hebrew-highlight");
+
+  // Clear + deselect
+  const cl = page.getByRole("button", { name: "Clear Highlight" }).first();
+  if (await cl.isVisible().catch(() => false)) { await cl.click(); await page.waitForTimeout(600); }
+  await chip(page, "s"); await chip(page, "sh"); await chip(page, "ts");
+
+  // Page 13: Tooltip
+  await pickMode(page, "Transliteration");
+  const tip = page.locator("span[title]").filter({ hasText: "i" }).first();
+  if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(1000); await snap(page, "07-page13-tooltip"); await page.mouse.move(0, 0); await page.waitForTimeout(300); }
+
+  // Pages 16-17: Letter Distribution in Hebrew OHB
+  await pickMode(page, "Hebrew OHB");
+  const lb = page.getByRole("button", { name: /Hebrew Letter/i });
+  if (await lb.isVisible().catch(() => false)) {
+    await lb.click(); await page.waitForTimeout(1500);
+    await snap(page, "08-page16-letter-panel");
+    await chip(page, "ל");
+    const h3 = page.getByRole("button", { name: "Smart Highlight" }).first();
+    if (await h3.isVisible().catch(() => false)) { await h3.click({ force: true }); await page.waitForTimeout(1500); await snap(page, "09-page17-letter-highlight"); }
   }
-  console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length);
-});
 
+  // Page 14: Disclaimer
+  const acc = page.locator(".accordion").first();
+  if (await acc.isVisible().catch(() => false)) { await acc.evaluate(el => el.scrollTop = el.scrollHeight); await page.waitForTimeout(500); await snap(page, "10-page14-disclaimer"); }
+
+  console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
+});

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-l3x587v8l-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-itxikw7rl-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjM5MDQsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJVDV0Qk0zUjR3SHhhTUJWZjh1bGNMUUJqIiwic3QiOiJzaWduX2luX3Rva2VuIn0.B9I99h5NPMDspxCVia3dkc_vCUce0FuBuxsvgsWlQ1LCD8bB5PtlkFhBGxX8d-v0mXJS35QA6dEDPexSdgxtOWH7viC8JAo4A50OyvbZ9CyjiXgIyM6TRHbLpG_GyFHKXgwqIXeXBOh3a7ZrGalJIozjFtOx_OoG-N4OvZ9b1Q5z9KEyiUrScHy1uPjDVyo7rj24n7WvNvLnxhbbIW3DPIvISaowDjMi-VYBoH8f1xt-Vk29Scmjs_bqyqjW_e_kRz0DOEkYmTeUyzcaUzSh9VM4ybTAs6Dpob2woLZGr9gbHVEGAOZKZpePIzsUvkLsC81FuSpxiUpepwklE2GUCQ";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjQxOTAsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJVGZ2ak9OQWpzNkNJcmpJQXJrSWlaUjBNIiwic3QiOiJzaWduX2luX3Rva2VuIn0.YAVOqVQPjTlObhzBtYmPxgvm6Vv4Zc-jwEMUjG_cJvg3DKWN0MeFP752WNqLpJrj0wmW6ZIsMwRziPUDwyEHA6iVW0wLM7qxcucbVW_xCmZNejGQFv_F5-mflTOLTBQH_YUsfaHiUkVfS8411uPHn66eejqkvCTzUJDyXt2VIeBnZ1J30acrp6WeimDF4ijxbBj5D7dnfbKy0itUY8JQ9a_M3ru5S1xbSd4G38iCFEOiSd-ZtS32eunbz-oTleYZ2whzRG6gfeVzWrVbtDRMv1JjNe5J8AvVzVFLkGKj2H7azUk1ZNnO5q0QAUvGO56Sp1lEV4ojv4cWRuAIVSP9vQ";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -83,3 +83,5 @@ test("match PDF at 200%", async ({ page }) => {
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
+
+

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,19 +2,20 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-t2j8mnqnr-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-l3x587v8l-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjI3NDksImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJUWtsTWtiaG9pa2tOaFlja01XT2RFZXdSIiwic3QiOiJzaWduX2luX3Rva2VuIn0.afkF21pwG10eqQKipc2iG7BsWsPyXtWNrfz7B6qP83-lDGwObMyzl2wHNMhXbISaTr-bcEJXvQBDmBztda2kKeH8IoEVUL2Dtk0brRszWTOHjU1crU26c5sWR874-RlIituxYkmqvFtyS1_cWkaGyKPeMtVmk362ALbb5eUl6EIDLAzXlQY6YQDyTMO1HJbwkcIdWTLd_6zkN-cKxK11aDocVyg7jPoD4DS19Mf5U6pOI57qIg2nFg3xaocRstaUaSuIQukuAeG_91H4PQKj7KAEZrp3ItyzqL05xkLR8iafDIUOycfS4MiLpG3xqgLxLNpufZZR6uiJY62fwA5Cdw";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NjM5MDQsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJVDV0Qk0zUjR3SHhhTUJWZjh1bGNMUUJqIiwic3QiOiJzaWduX2luX3Rva2VuIn0.B9I99h5NPMDspxCVia3dkc_vCUce0FuBuxsvgsWlQ1LCD8bB5PtlkFhBGxX8d-v0mXJS35QA6dEDPexSdgxtOWH7viC8JAo4A50OyvbZ9CyjiXgIyM6TRHbLpG_GyFHKXgwqIXeXBOh3a7ZrGalJIozjFtOx_OoG-N4OvZ9b1Q5z9KEyiUrScHy1uPjDVyo7rj24n7WvNvLnxhbbIW3DPIvISaowDjMi-VYBoH8f1xt-Vk29Scmjs_bqyqjW_e_kRz0DOEkYmTeUyzcaUzSh9VM4ybTAs6Dpob2woLZGr9gbHVEGAOZKZpePIzsUvkLsC81FuSpxiUpepwklE2GUCQ";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
 const openDD = async (p: Page) => { const c=p.locator('label[for="toggleLang"] svg').first(); if(await c.isVisible().catch(()=>false)){await c.click();await p.waitForTimeout(500);} };
 const pickMode = async (p: Page, l: string) => { await openDD(p); await p.locator('.shadow-lg button:has-text("'+l+'")').last().click(); await p.waitForTimeout(1200); };
-const setZoom = async (p: Page, pct: string) => { const t=p.locator('#scaleInput').locator('..'); await t.click(); await p.waitForTimeout(500); const o=p.locator('li:has-text("'+pct+'")'); if(await o.isVisible().catch(()=>false)){await o.click();await page.waitForTimeout(1500);} };
+const zoom = async (p: Page, pct: string) => { const t=p.locator('#scaleInput').locator('..'); await t.click(); await p.waitForTimeout(500); const o=p.locator('li:has-text("'+pct+'")'); if(await o.isVisible().catch(()=>false)){await o.click();await p.waitForTimeout(1500);} };
 
-test.use({ viewport: { width: 1440, height: 810 } });
+// Use WIDER viewport so 200% zoom fits with sidebar
+test.use({ viewport: { width: 1920, height: 1080 } });
 
-test("final capture", async ({ page }) => {
+test("match PDF at 200%", async ({ page }) => {
   test.setTimeout(180_000);
   await page.goto(baseUrl + "/sign-in?__clerk_ticket=" + token);
   await page.waitForTimeout(8000);
@@ -27,69 +28,48 @@ test("final capture", async ({ page }) => {
     console.log("retry " + (i+1)); await page.waitForTimeout(3000);
   }
 
-  // Helper to set zoom via dropdown
-  const zoom = async (pct: string) => {
-    const t = page.locator('#scaleInput').locator('..');
-    await t.click(); await page.waitForTimeout(500);
-    const o = page.locator('li:has-text("' + pct + '")');
-    if (await o.isVisible().catch(() => false)) { await o.click(); await page.waitForTimeout(1500); }
-  };
-
-  // ================================================================
-  // PAGES 4-5: Dropdown views at 200% (no sidebar, full passage)
-  // ================================================================
-  await zoom("200%");
-
-  // Page 4: Aא parallel + transliteration
+  // Aא parallel mode for everything
   await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
   await page.waitForTimeout(800);
+
+  // PAGE 4: 200% + transliteration + dropdown open
+  await zoom(page, "200%");
   await pickMode(page, "Hebrew Transliteration");
   await openDD(page);
   await snap(page, "01-page4-match");
   await page.mouse.click(100, 400); await page.waitForTimeout(300);
+  await snap(page, "02-page5-transliteration");
 
-  // Page 5: א transliteration + dropdown
-  await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
-  await page.waitForTimeout(800);
-  await pickMode(page, "Transliteration");
-  await openDD(page);
-  await snap(page, "02-page5-match");
-  await page.mouse.click(100, 400); await page.waitForTimeout(300);
-
-  // ================================================================
-  // PAGES 7-13: Sounds features at 100% (sidebar + passage must fit)
-  // Stay in א transliteration mode (matching PDF page 11)
-  // ================================================================
-  await zoom("100%");
+  // PAGES 7-13: Open Sounds panel — stay at 200%
   const sb = page.getByRole("button", { name: "Sounds" });
   await sb.click({ force: true }); await page.waitForTimeout(1500);
   await snap(page, "03-page7-sounds-panel");
 
-  // Page 11: s/sh/ts selected, Smart Highlight button visible (not yet clicked)
+  // PAGE 11: s/sh/ts selected, Smart Highlight NOT yet clicked (button blue)
   await chip(page, "s"); await chip(page, "sh"); await chip(page, "ts");
   await snap(page, "04-page11-chips-selected");
 
-  // Click Smart Highlight
+  // Click Smart Highlight — highlights appear
   const hlBtn = page.getByRole("button", { name: "Smart Highlight" }).first();
   if (await hlBtn.isVisible().catch(() => false)) { await hlBtn.click({ force: true }); await page.waitForTimeout(1500); }
   await snap(page, "05-page11-highlight-on");
 
-  // Page 12: Switch to Hebrew OHB
+  // PAGE 12: Switch to Hebrew OHB (still parallel)
   await pickMode(page, "Hebrew OHB");
   await page.waitForTimeout(1000);
   await snap(page, "06-page12-hebrew-highlight");
 
-  // Clear + deselect
+  // Clear for tooltip
   const cl = page.getByRole("button", { name: "Clear Highlight" }).first();
   if (await cl.isVisible().catch(() => false)) { await cl.click(); await page.waitForTimeout(600); }
   await chip(page, "s"); await chip(page, "sh"); await chip(page, "ts");
 
-  // Page 13: Tooltip
-  await pickMode(page, "Transliteration");
+  // PAGE 13: Tooltip
+  await pickMode(page, "Hebrew Transliteration");
   const tip = page.locator("span[title]").filter({ hasText: "i" }).first();
   if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(1000); await snap(page, "07-page13-tooltip"); await page.mouse.move(0, 0); await page.waitForTimeout(300); }
 
-  // Pages 16-17: Letter Distribution in Hebrew OHB
+  // PAGES 16-17: Letter Distribution (Hebrew OHB)
   await pickMode(page, "Hebrew OHB");
   const lb = page.getByRole("button", { name: /Hebrew Letter/i });
   if (await lb.isVisible().catch(() => false)) {
@@ -97,14 +77,9 @@ test("final capture", async ({ page }) => {
     await snap(page, "08-page16-letter-panel");
     await chip(page, "ל");
     const h3 = page.getByRole("button", { name: "Smart Highlight" }).first();
-    if (await h3.isVisible().catch(() => false)) { await h3.click({ force: true }); await page.waitForTimeout(1500); await snap(page, "09-page17-letter-highlight"); }
+    if (await h3.isVisible().catch(() => false)) { await h3.click({ force: true }); await page.waitForTimeout(1500); }
+    await snap(page, "09-page17-letter-highlight");
   }
-
-  // Page 14: Disclaimer
-  const acc = page.locator(".accordion").first();
-  if (await acc.isVisible().catch(() => false)) { await acc.evaluate(el => el.scrollTop = el.scrollHeight); await page.waitForTimeout(500); await snap(page, "10-page14-disclaimer"); }
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
-
-

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -1,0 +1,68 @@
+import { test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+const baseUrl = "https://sela-webapp-kidcw8ic4-sela-webapp.vercel.app";
+const studyId = "cs8p4poa9c1akf2sireg";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg1NjQ0MDYsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NGRFFKQmt5TkVENExLSkxEN0NlWlNhb21zIiwic3QiOiJzaWduX2luX3Rva2VuIn0.ZQmqwy_HSyfp8mnNq1yhw9cH6TLVd-qWLjlEJ_e9T-PqgjnZylj57iuSaha2TOLrL-4A4Ft_LtkbPai6BLmTRggRUeWzoCu2DoBz35RGpt3Tx0p2q76Vk40g79CoLjK52OeQHvuyog4T-q1_yQBzgJ_rCWKit3RgYkKlJPe0r4Njs4akohJORyzb_9R8Lqykhjqz76pX5NGS5VrSXlSFYlgS5dZccLoGWlfQ_TFUJOhikX9tbWUFlrmb1sJ7Mg3-p01ivlxbiDg_9VYhdtbBHM8k11eym8mBLG_PPiy00d4LT5d8D57ffLDO6TLn5jV4e_0LV3CRVNEWf_AFKXAhhA";
+const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
+const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
+const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
+
+test.use({ viewport: { width: 1600, height: 900 } });
+
+test("capture Psalm 23", async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto(baseUrl + "/sign-in?__clerk_ticket=" + token);
+  await page.waitForTimeout(8000);
+  console.log("Login URL:", page.url());
+  
+  await page.goto(baseUrl + "/study/" + studyId + "/edit?t=" + Date.now(), { waitUntil: "domcontentloaded", timeout: 20_000 }).catch(() => {});
+  await page.waitForTimeout(6000);
+  console.log("Study URL:", page.url());
+  await page.evaluate(() => { (document.body.style as any).zoom = "0.85"; });
+  await page.waitForTimeout(1000);
+  await snap(page, "01-study-loaded");
+
+  const tg = page.locator('label[for="toggleLang"]');
+  if (await tg.isVisible().catch(() => false)) {
+    await page.locator('label[for="toggleLang"] span').first().click();
+    await page.waitForTimeout(600);
+    await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
+    await page.waitForTimeout(1000);
+    await snap(page, "02-parallel-mode");
+    const sel = page.locator("select").first();
+    if (await sel.isVisible().catch(() => false)) {
+      console.log("✅ Dropdown");
+      await sel.selectOption({ index: 1 });
+      await page.waitForTimeout(1200);
+      await snap(page, "03-transliteration");
+      await sel.selectOption({ index: 0 });
+      await page.waitForTimeout(800);
+    }
+  }
+  const sb = page.getByRole("button", { name: "Sounds" });
+  if (await sb.isVisible().catch(() => false)) {
+    await sb.click({ force: true }); await page.waitForTimeout(1500); await snap(page, "04-sounds-panel");
+    const tip = page.locator("span[title]").filter({ hasText: "i" }).first();
+    if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(800); await snap(page, "05-tooltip"); await page.mouse.move(0,0); await page.waitForTimeout(300); }
+    try { await chip(page,"sh"); await snap(page,"06-sh-selected");
+      const h=page.getByRole("button",{name:"Smart Highlight"}).first();
+      if(await h.isVisible().catch(()=>false)){await h.click({force:true});await page.waitForTimeout(1200);await snap(page,"07-smart-highlight");
+      const c=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c.isVisible().catch(()=>false)){await c.click();await page.waitForTimeout(600);}}
+      await chip(page,"sh");} catch(e){console.log(e);}
+    try { await chip(page,"sh"); await chip(page,"m");
+      const h2=page.getByRole("button",{name:"Smart Highlight"}).first();
+      if(await h2.isVisible().catch(()=>false)){await h2.click({force:true});await page.waitForTimeout(1200);await snap(page,"08-multi-highlight");
+      const c2=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c2.isVisible().catch(()=>false)){await c2.click();await page.waitForTimeout(500);}
+      }await chip(page,"sh");await chip(page,"m");} catch{}
+    const lb=page.getByRole("button",{name:/Hebrew Letter/i});
+    if(await lb.isVisible().catch(()=>false)){await lb.click();await page.waitForTimeout(1500);await snap(page,"09-letter-panel");
+      try{await chip(page,"ל");const h3=page.getByRole("button",{name:"Smart Highlight"}).first();
+      if(await h3.isVisible().catch(()=>false)){await h3.click({force:true});await page.waitForTimeout(1200);await snap(page,"10-letter-highlight");
+      const c3=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c3.isVisible().catch(()=>false)){await c3.click();await page.waitForTimeout(500);}}}catch{}}
+    const acc=page.locator(".accordion").first();
+    if(await acc.isVisible().catch(()=>false)){await acc.evaluate(el=>el.scrollTop=el.scrollHeight);await page.waitForTimeout(500);await snap(page,"11-disclaimer");}
+  }
+  console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length);
+});

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-i8z5odh4i-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-k605dhx9s-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3MDQ2ODcsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NKbmwzamU3aUpsVXFScmNPeGx6S3k4aTdwIiwic3QiOiJzaWduX2luX3Rva2VuIn0.SVNoCWKlpmPCZvrmXEo7JgyygRNnVaZQrhs9FB1_DZNmTlF5Q6HHY6qx9-PQ4153FRgX0ww5lWwa8dG-3Usgjz25bnzWD9zZ7ltuZdyixlvqZHw4WpPKeyB2bNdHEmow_8o9L61kEYLqwmEqOW8S-zDV7yT3-TAQ9Gc7raHfNIHqH5IHl2ohRypCt76iGHcC8CXSFdY5pSUkXZLKHjKp_N-yqOMUVk3yhee5EasW1JqQdguVTZu2CwvcUe-7yAsd5kRyZdLDLzkfeyQx1Jxi9siyRo4V6Zx8Mg3YF8myy7Sbw-FS1UiXiYC8zF8J2alIBfwN38ES-MTGGTsnEhLYKA";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3MTA5NzUsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NLMFZIaGlCUXp3YzYxcXNHZklOZ0JMTExjIiwic3QiOiJzaWduX2luX3Rva2VuIn0.BT3a1E-tetAMkgz5pCZjh23zW6_PXXZ_Je1CLVJ2Ydon5ZMpRfPb-5348q-fozF7xCfFWMh8ox3wkAnUPtF9ocwU-EhDo_OUzrvG9et5tPTHFvSSvlMXsSywWKn6kcWZLv6kcgrx3GJuZb1YzbHwtxU7u6AniVAzkUAqnY7LAkSqK_KnYaGFh-Ob2LrJJguSRnqYiDcKom2EepOyvqVzsXlK6xXl7OaTmk967J_4Q-CvRDYWWizppxGwMUn2tbBEjCwvAMB4bzIOcCpY5ZVVs5RS0UtCvtUYhOGwTcfBh1p-qqC5l3aEQ2DIuRbU9knyITUvfruqnNg9GbnElJ0jdQ";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -88,3 +88,5 @@ test("final capture", async ({ page }) => {
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
+
+

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-8c7zt8z5l-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-aa7ixr4ax-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3OTM3MTQsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NNaUNwenJmZlRSVW5zNUpwMVdBR01WNlY3Iiwic3QiOiJzaWduX2luX3Rva2VuIn0.gazsiZVG5SiZUPu7BAIWTsUZSCAW7637qOXTX8rihUsJ6AxaRCHyD8F7q0BTnq8lH3CLosF3k4HpIsRXGE6Viao4Kvmdh9BT7cFT1RzG5O7jT0O8RyhhHQKfgeSCPDW156bG3Vxgma2HNwfBiXEImuHRjZ_vmFPLC2D1ZJu7g579FuqjDa7ViR88YFcA2SfvnQ8ZZQ35JIbpN0R-LPZ849UaJsyf_VQg3UwPYsDZYy3LjlJzxZZEwOG3EHxkpGkn3E0gTI058nDmvnD4C50bc5XwuLWJeE1_4CocwFY6HayRkR9374pvRXmu1irkCjXusbok1LANTlNeroI5aVhMCA";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3OTY4NDAsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NNb1hlQ2xHRTV1QlVyUHBBYVdWV2JTRXk5Iiwic3QiOiJzaWduX2luX3Rva2VuIn0.LTwFI7VDB6ItVm9UCN_5RmyB76DiRDa79R-zvbl7jNEmyaRPkL0ARpx5iZ_Dq-PfdSOlycayvHiG61I8w18XMRwBbjuTIRQHu9_J1Rm0uMVSInlbcBr0adsktwhfr2d7f89GkBrZIvBIUt2ZkMEyKl2Hblb2gFuahc4xsRG_smiCbTqyFZPTEJcO8Cbwizk-uE3dFzkiH54jHvy8oIeDiDVDSDhYtFbRt4X9NHkVg46KSbSjzNp3rnmHjMLgrcGbZizcQuhlawM8cqtB2D8GWxiSXkJPr4RvvYxhYopCEbnvZ_eijRMBJgqxm9PK-qCPV_R4VhN7sjbjINE2oG-CfA";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -88,6 +88,8 @@ test("final capture", async ({ page }) => {
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
+
+
 
 
 

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,68 +2,131 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-fugqxk5ml-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-25ztgh1ri-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg1NjQ3MDcsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NGRTI0VWk1a1J6NFJxTVd4QU5JYW9pUHJQIiwic3QiOiJzaWduX2luX3Rva2VuIn0.VuLXssVmHf_0nQIVr853m2P4kzBF0wRxVOn_ekiFHTcAM-eHamh4E1KiSNAfIzKerplXtO9M4dc8ELceEbzlTPVH-pxPRMHrfDOdMIJM24_tBdnqaxAE8K2MMucg2CSo4h7wVXVkaPMu70QdJeno_M0mOBmKDQIQsNmNNUoOzjeabOPa8peoUepbwlf-A5m35r0bHwtvJtcQQr57RGjh1WsrarKewlPj4fJRNvoRL2_QVW_KTqyttCNwARIBkxOVJflNGMB8hfyWSb5OMDQkJYugYed_TaAQJiIvSgsRmwZEYv-WtGBNDN7Xe1sh1a6-ynIeaWJ2nvYNYp_xrk5imQ";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg2NTg2MjgsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NJSU91Z2Q3Vm90N0JBbU5aSEFGYmpMdHhNIiwic3QiOiJzaWduX2luX3Rva2VuIn0.J2NZulXECU0ReuJynLtgALCDLVlFV_sKjadJD1jNyqfWCeh5SrPpCy0r0FxJBa6OS1ZClOr8Y_xpYh3mw7pXejXBv2YnHUx1j5puSeBdRrJQ2FGAHOGg7ZwjRgTNUG0GSw087vpbEctTxhDuwiSxu_nrfjiaGMMToEpIgkMtg6ZZ-cCDMdLmPkU6irYjAPygWYronnkeZ0ABTCE8nvioOftecjuEyXGFhQiX0FmOjJL9-RocSksmiG2XLJZxrH3xjJFjisq9ydm_Xrq1no6KHHwfgS4_3JQvh10zyyTtytRwFXt3149kQbXJqQPedau1vhsPhY1ezXMEQEf30m4sVg";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
 
 test.use({ viewport: { width: 1600, height: 900 } });
 
-test("capture Psalm 23", async ({ page }) => {
-  test.setTimeout(120_000);
+test("capture all dropdown states + features", async ({ page }) => {
+  test.setTimeout(180_000);
+  
+  // Login
   await page.goto(baseUrl + "/sign-in?__clerk_ticket=" + token);
   await page.waitForTimeout(8000);
-  console.log("Login URL:", page.url());
+
+  // Load Psalm 23
+  for (let i = 0; i < 5; i++) {
+    await page.goto(baseUrl + "/study/" + studyId + "/edit?t=" + Date.now(), { waitUntil: "domcontentloaded", timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(5000);
+    if (!(await page.locator("text=Application error").isVisible().catch(() => false))) {
+      const ok = await page.locator('label[for="toggleLang"]').isVisible().catch(() => false);
+      if (ok) { console.log("✅ Study loaded"); break; }
+    }
+    console.log("retry " + (i+1));
+    await page.waitForTimeout(3000);
+  }
   
-  await page.goto(baseUrl + "/study/" + studyId + "/edit?t=" + Date.now(), { waitUntil: "domcontentloaded", timeout: 20_000 }).catch(() => {});
-  await page.waitForTimeout(6000);
-  console.log("Study URL:", page.url());
   await page.evaluate(() => { (document.body.style as any).zoom = "0.85"; });
   await page.waitForTimeout(1000);
-  await snap(page, "01-study-loaded");
 
-  const tg = page.locator('label[for="toggleLang"]');
-  if (await tg.isVisible().catch(() => false)) {
-    await page.locator('label[for="toggleLang"] span').first().click();
+  // === DROPDOWN SCREENSHOTS (matching PDF pages 2-5 exactly) ===
+  
+  // 1. A mode — click A, show chevron, open dropdown showing "English Gloss" (PDF Page 3)
+  await page.locator('label[for="toggleLang"] span').first().click(); // click A
+  await page.waitForTimeout(800);
+  await snap(page, "01-A-mode-english");
+  // Open A dropdown
+  const chevA = page.locator('label[for="toggleLang"] svg').first();
+  if (await chevA.isVisible().catch(() => false)) {
+    await chevA.click();
     await page.waitForTimeout(600);
-    await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
-    await page.waitForTimeout(1000);
-    await snap(page, "02-parallel-mode");
-    const sel = page.locator("select").first();
-    if (await sel.isVisible().catch(() => false)) {
-      console.log("✅ Dropdown");
-      await sel.selectOption({ index: 1 });
-      await page.waitForTimeout(1200);
-      await snap(page, "03-transliteration");
-      await sel.selectOption({ index: 0 });
+    await snap(page, "02-A-dropdown-open");  // Shows "English Gloss" 
+    // Close
+    await page.mouse.click(400, 400);
+    await page.waitForTimeout(400);
+  }
+
+  // 2. Aא mode — click Aא, open dropdown showing 3 options (PDF Page 4)
+  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
+  await page.waitForTimeout(1000);
+  await snap(page, "03-Ax-mode-parallel");
+  // Open Aא dropdown
+  const chevAx = page.locator('label[for="toggleLang"] svg').first();
+  if (await chevAx.isVisible().catch(() => false)) {
+    await chevAx.click();
+    await page.waitForTimeout(600);
+    await snap(page, "04-Ax-dropdown-3-options");  // Shows 3 options!
+    // Select "English Gloss / Hebrew Transliteration"
+    await page.locator('.shadow-lg button:has-text("Hebrew Transliteration")').last().click();
+    await page.waitForTimeout(1200);
+    await snap(page, "05-transliteration-active");
+    // Back to Hebrew OHB
+    const chevAx2 = page.locator('label[for="toggleLang"] svg').first();
+    if (await chevAx2.isVisible().catch(() => false)) {
+      await chevAx2.click();
+      await page.waitForTimeout(500);
+      await page.locator('.shadow-lg button:has-text("Hebrew OHB")').click();
       await page.waitForTimeout(800);
     }
   }
+
+  // 3. א mode — click א, open dropdown showing 2 options (PDF Page 5)
+  await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
+  await page.waitForTimeout(1000);
+  await snap(page, "06-x-mode-hebrew");
+  const chevX = page.locator('label[for="toggleLang"] svg').first();
+  if (await chevX.isVisible().catch(() => false)) {
+    await chevX.click();
+    await page.waitForTimeout(600);
+    await snap(page, "07-x-dropdown-2-options");  // Shows "Hebrew OHB" + "Transliteration"
+    // Close
+    await page.mouse.click(400, 400);
+    await page.waitForTimeout(400);
+  }
+
+  // Back to parallel for Sounds features
+  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
+  await page.waitForTimeout(800);
+
+  // === SOUND DISTRIBUTION SCREENSHOTS ===
   const sb = page.getByRole("button", { name: "Sounds" });
   if (await sb.isVisible().catch(() => false)) {
-    await sb.click({ force: true }); await page.waitForTimeout(1500); await snap(page, "04-sounds-panel");
+    await sb.click({ force: true }); await page.waitForTimeout(1500);
+    await snap(page, "08-sounds-panel");
+    
+    // Tooltip
     const tip = page.locator("span[title]").filter({ hasText: "i" }).first();
-    if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(800); await snap(page, "05-tooltip"); await page.mouse.move(0,0); await page.waitForTimeout(300); }
-    try { await chip(page,"sh"); await snap(page,"06-sh-selected");
+    if (await tip.isVisible().catch(() => false)) { await tip.hover(); await page.waitForTimeout(800); await snap(page, "09-tooltip"); await page.mouse.move(0,0); await page.waitForTimeout(300); }
+    
+    // sh chip + highlight
+    try { await chip(page,"sh"); await snap(page,"10-sh-selected");
       const h=page.getByRole("button",{name:"Smart Highlight"}).first();
-      if(await h.isVisible().catch(()=>false)){await h.click({force:true});await page.waitForTimeout(1200);await snap(page,"07-smart-highlight");
+      if(await h.isVisible().catch(()=>false)){await h.click({force:true});await page.waitForTimeout(1200);await snap(page,"11-smart-highlight");
       const c=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c.isVisible().catch(()=>false)){await c.click();await page.waitForTimeout(600);}}
       await chip(page,"sh");} catch(e){console.log(e);}
+    
+    // Multi
     try { await chip(page,"sh"); await chip(page,"m");
       const h2=page.getByRole("button",{name:"Smart Highlight"}).first();
-      if(await h2.isVisible().catch(()=>false)){await h2.click({force:true});await page.waitForTimeout(1200);await snap(page,"08-multi-highlight");
+      if(await h2.isVisible().catch(()=>false)){await h2.click({force:true});await page.waitForTimeout(1200);await snap(page,"12-multi-highlight");
       const c2=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c2.isVisible().catch(()=>false)){await c2.click();await page.waitForTimeout(500);}
       }await chip(page,"sh");await chip(page,"m");} catch{}
+    
+    // Letters
     const lb=page.getByRole("button",{name:/Hebrew Letter/i});
-    if(await lb.isVisible().catch(()=>false)){await lb.click();await page.waitForTimeout(1500);await snap(page,"09-letter-panel");
+    if(await lb.isVisible().catch(()=>false)){await lb.click();await page.waitForTimeout(1500);await snap(page,"13-letter-panel");
       try{await chip(page,"ל");const h3=page.getByRole("button",{name:"Smart Highlight"}).first();
-      if(await h3.isVisible().catch(()=>false)){await h3.click({force:true});await page.waitForTimeout(1200);await snap(page,"10-letter-highlight");
+      if(await h3.isVisible().catch(()=>false)){await h3.click({force:true});await page.waitForTimeout(1200);await snap(page,"14-letter-highlight");
       const c3=page.getByRole("button",{name:"Clear Highlight"}).first();if(await c3.isVisible().catch(()=>false)){await c3.click();await page.waitForTimeout(500);}}}catch{}}
+    
+    // Disclaimer
     const acc=page.locator(".accordion").first();
-    if(await acc.isVisible().catch(()=>false)){await acc.evaluate(el=>el.scrollTop=el.scrollHeight);await page.waitForTimeout(500);await snap(page,"11-disclaimer");}
+    if(await acc.isVisible().catch(()=>false)){await acc.evaluate(el=>el.scrollTop=el.scrollHeight);await page.waitForTimeout(500);await snap(page,"15-disclaimer");}
   }
-  console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length);
+  
+  console.log("🎉 " + fs.readdirSync(dir).filter(f=>f.endsWith(".png")).length + " screenshots");
 });
-

--- a/tests/capture.spec.ts
+++ b/tests/capture.spec.ts
@@ -2,9 +2,9 @@ import { test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
-const baseUrl = "https://sela-webapp-k605dhx9s-sela-webapp.vercel.app";
+const baseUrl = "https://sela-webapp-8c7zt8z5l-sela-webapp.vercel.app";
 const studyId = "cs8p4poa9c1akf2sireg";
-const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3MTA5NzUsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NLMFZIaGlCUXp3YzYxcXNHZklOZ0JMTExjIiwic3QiOiJzaWduX2luX3Rva2VuIn0.BT3a1E-tetAMkgz5pCZjh23zW6_PXXZ_Je1CLVJ2Ydon5ZMpRfPb-5348q-fozF7xCfFWMh8ox3wkAnUPtF9ocwU-EhDo_OUzrvG9et5tPTHFvSSvlMXsSywWKn6kcWZLv6kcgrx3GJuZb1YzbHwtxU7u6AniVAzkUAqnY7LAkSqK_KnYaGFh-Ob2LrJJguSRnqYiDcKom2EepOyvqVzsXlK6xXl7OaTmk967J_4Q-CvRDYWWizppxGwMUn2tbBEjCwvAMB4bzIOcCpY5ZVVs5RS0UtCvtUYhOGwTcfBh1p-qqC5l3aEQ2DIuRbU9knyITUvfruqnNg9GbnElJ0jdQ";
+const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Nzg3OTM3MTQsImlpZCI6Imluc18yYkQ1TGpzZEc1dWNnWDJDbHFpNlIzZ2VQdWgiLCJzaWQiOiJzaXRfM0NNaUNwenJmZlRSVW5zNUpwMVdBR01WNlY3Iiwic3QiOiJzaWduX2luX3Rva2VuIn0.gazsiZVG5SiZUPu7BAIWTsUZSCAW7637qOXTX8rihUsJ6AxaRCHyD8F7q0BTnq8lH3CLosF3k4HpIsRXGE6Viao4Kvmdh9BT7cFT1RzG5O7jT0O8RyhhHQKfgeSCPDW156bG3Vxgma2HNwfBiXEImuHRjZ_vmFPLC2D1ZJu7g579FuqjDa7ViR88YFcA2SfvnQ8ZZQ35JIbpN0R-LPZ849UaJsyf_VQg3UwPYsDZYy3LjlJzxZZEwOG3EHxkpGkn3E0gTI058nDmvnD4C50bc5XwuLWJeE1_4CocwFY6HayRkR9374pvRXmu1irkCjXusbok1LANTlNeroI5aVhMCA";
 const dir = path.resolve("C:/Users/brian/Repos/Github Copilot CLI Prompt Docs/sela-webapp/Sound Display Transliteration/live");
 const snap = async (p: Page, n: string) => { fs.mkdirSync(dir,{recursive:true}); await p.screenshot({path:path.join(dir,n+".png"),fullPage:false}); console.log("📸 "+n); };
 const chip = async (p: Page, l: string) => { const b=p.locator("button.wordBlock"); for(let i=0;i<await b.count();i++){if((await b.nth(i).innerText()).replace(/\s+/g,"").startsWith(l)){await b.nth(i).click();await p.waitForTimeout(600);return;}} };
@@ -88,5 +88,7 @@ test("final capture", async ({ page }) => {
 
   console.log("🎉 " + fs.readdirSync(dir).filter(f => f.endsWith(".png")).length);
 });
+
+
 
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -49,14 +49,14 @@ export const switchToHebrewMode = async (page: Page) => {
 /** Select a display mode from the popover dropdown. */
 export const selectDisplayMode = async (
   page: Page,
-  label: "English Gloss / Hebrew OHB" | "English Gloss / Hebrew Transliteration",
+  label: "English Gloss / Hebrew OHB" | "English / Transliteration" | "English Gloss / Hebrew Transliteration" | "Hebrew OHB" | "Transliteration",
 ) => {
   // Click the chevron on the active toggle button to open the dropdown
   const chevron = page.locator('label[for="toggleLang"] svg').first();
   await chevron.click();
   await page.waitForTimeout(PAUSE);
   // Click the option in the popover
-  await page.locator(`button:has-text("${label}")`).click();
+  await page.locator(`.shadow-lg button:has-text("${label}")`).click();
   await page.waitForTimeout(PAUSE);
 };
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -37,7 +37,7 @@ export const waitForStudyLoad = async (page: Page) => {
 /** Switch the language toggle to Parallel mode (Aא). */
 export const switchToParallelMode = async (page: Page) => {
   await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
-  await expect(page.locator("select")).toBeVisible();
+  await page.waitForTimeout(PAUSE);
 };
 
 /** Switch the language toggle to Hebrew-only mode (א). */
@@ -46,12 +46,17 @@ export const switchToHebrewMode = async (page: Page) => {
   await page.waitForTimeout(PAUSE);
 };
 
-/** Select a display mode from the dropdown. */
+/** Select a display mode from the popover dropdown. */
 export const selectDisplayMode = async (
   page: Page,
-  label: "English Gloss / Hebrew OHB" | "English / Transliteration" | "English Gloss / Hebrew Transliteration",
+  label: "English Gloss / Hebrew OHB" | "English Gloss / Hebrew Transliteration",
 ) => {
-  await page.locator("select").selectOption({ label });
+  // Click the chevron on the active toggle button to open the dropdown
+  const chevron = page.locator('label[for="toggleLang"] svg').first();
+  await chevron.click();
+  await page.waitForTimeout(PAUSE);
+  // Click the option in the popover
+  await page.locator(`button:has-text("${label}")`).click();
   await page.waitForTimeout(PAUSE);
 };
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,177 @@
+import { expect, type Page, type Locator } from "@playwright/test";
+import path from "path";
+
+/* ------------------------------------------------------------------ */
+/*  Configuration                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The study path used for E2E tests. Override via TEST_STUDY_PATH env var
+ * to test against a different study.
+ */
+export const STUDY_PATH =
+  process.env.TEST_STUDY_PATH ?? "/study/d6ef7cl250emugaodqi0/view";
+
+/**
+ * Pause between visual steps (ms). Set to 0 for CI, higher for headed reviews.
+ */
+export const PAUSE = process.env.CI ? 0 : Number(process.env.TEST_PAUSE ?? 600);
+
+/**
+ * Directory for screenshot evidence. Relative to the repo root by default.
+ */
+export const EVIDENCE_DIR = path.resolve(
+  process.env.TEST_EVIDENCE_DIR ?? path.join(__dirname, "..", "test-results", "evidence"),
+);
+
+/* ------------------------------------------------------------------ */
+/*  Navigation helpers                                                */
+/* ------------------------------------------------------------------ */
+
+/** Navigate to the study and wait for the study pane to render. */
+export const waitForStudyLoad = async (page: Page) => {
+  await page.goto(STUDY_PATH);
+  await page.waitForSelector('label[for="toggleLang"]', { timeout: 60_000 });
+};
+
+/** Switch the language toggle to Parallel mode (Aא). */
+export const switchToParallelMode = async (page: Page) => {
+  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
+  await expect(page.locator("select")).toBeVisible();
+};
+
+/** Switch the language toggle to Hebrew-only mode (א). */
+export const switchToHebrewMode = async (page: Page) => {
+  await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
+  await page.waitForTimeout(PAUSE);
+};
+
+/** Select a display mode from the dropdown. */
+export const selectDisplayMode = async (
+  page: Page,
+  label: "English Gloss / Hebrew OHB" | "English / Transliteration" | "English Gloss / Hebrew Transliteration",
+) => {
+  await page.locator("select").selectOption({ label });
+  await page.waitForTimeout(PAUSE);
+};
+
+/** Open the Sounds tab in the InfoPane sidebar. */
+export const openSoundsTab = async (page: Page) => {
+  await page.getByRole("button", { name: "Sounds" }).click();
+  await page.waitForTimeout(PAUSE);
+};
+
+/** Open a specific distribution section by name. */
+export const openDistributionSection = async (
+  page: Page,
+  name: "Hebrew Sound Distribution" | "Hebrew Letters Distribution",
+) => {
+  await page.getByRole("button", { name: new RegExp(name) }).click();
+  await page.waitForTimeout(PAUSE);
+};
+
+/* ------------------------------------------------------------------ */
+/*  Chip interaction helpers                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Click a distribution chip by its label text.
+ * Works for both sound chips ("sh", "kh/ch") and letter chips ("א", "שׁ").
+ */
+export const clickDistributionChip = async (page: Page, chipLabel: string) => {
+  const buttons = page.locator("button.wordBlock");
+  const count = await buttons.count();
+
+  for (let i = 0; i < count; i++) {
+    const text = (await buttons.nth(i).innerText()).replace(/\s+/g, "");
+    if (text.startsWith(chipLabel)) {
+      await buttons.nth(i).click();
+      await page.waitForTimeout(PAUSE);
+      return;
+    }
+  }
+  throw new Error(`Distribution chip "${chipLabel}" not found`);
+};
+
+/** Click the "Smart Highlight" or "Clear Highlight" button (first match). */
+export const clickSmartHighlight = async (page: Page) => {
+  const btn = page.getByRole("button", { name: /Smart Highlight|Clear Highlight/ }).first();
+  await btn.click();
+  await page.waitForTimeout(PAUSE);
+};
+
+/** Get the Smart Highlight button in the currently visible section. */
+export const getSmartHighlightButton = (page: Page) =>
+  page.getByRole("button", { name: /Smart Highlight|Clear Highlight/ }).first();
+
+/* ------------------------------------------------------------------ */
+/*  Highlight inspection helpers                                      */
+/* ------------------------------------------------------------------ */
+
+/** Locator for all inline highlight spans in the passage. */
+export const inlineHighlights = (page: Page): Locator =>
+  page.locator('#selaPassage [style*="background-color"]');
+
+/** Count inline highlights currently visible. */
+export const countInlineHighlights = (page: Page) =>
+  inlineHighlights(page).count();
+
+/**
+ * Collect the set of distinct background colors used by inline highlights.
+ * Useful for verifying that only selected chips' colors appear.
+ */
+export const collectHighlightColors = async (page: Page): Promise<Set<string>> => {
+  const highlights = inlineHighlights(page);
+  const count = await highlights.count();
+  const colors = new Set<string>();
+
+  for (let i = 0; i < Math.min(count, 50); i++) {
+    const style = await highlights.nth(i).getAttribute("style");
+    const match = style?.match(/background-color:\s*([^;]+)/);
+    if (match) colors.add(match[1].trim());
+  }
+  return colors;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Screenshot helpers                                                */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Save a screenshot to the evidence directory.
+ * The name should be a short kebab-case descriptor (no extension).
+ */
+export const screenshot = async (page: Page, name: string) => {
+  const fs = await import("fs");
+  fs.mkdirSync(EVIDENCE_DIR, { recursive: true });
+  await page.screenshot({
+    path: path.join(EVIDENCE_DIR, `${name}.png`),
+    fullPage: true,
+  });
+};
+
+/* ------------------------------------------------------------------ */
+/*  Assertion helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Assert that all inline highlights share exactly N distinct colors.
+ * Useful for verifying "only selected chips highlighted" behavior.
+ */
+export const expectHighlightColorCount = async (page: Page, expected: number) => {
+  const colors = await collectHighlightColors(page);
+  expect(colors.size).toBe(expected);
+};
+
+/**
+ * Assert that inline highlights exist and are on short text spans
+ * (individual letters/sounds, not full words).
+ */
+export const expectIndividualLetterHighlights = async (page: Page) => {
+  const count = await countInlineHighlights(page);
+  expect(count).toBeGreaterThan(0);
+
+  const first = inlineHighlights(page).first();
+  const text = await first.innerText();
+  expect(text.length).toBeLessThanOrEqual(3);
+};

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -1,69 +1,52 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  PAUSE,
+  waitForStudyLoad,
+  switchToParallelMode,
+  selectDisplayMode,
+  openSoundsTab,
+  openDistributionSection,
+  clickDistributionChip,
+  clickSmartHighlight,
+  getSmartHighlightButton,
+  inlineHighlights,
+  countInlineHighlights,
+  collectHighlightColors,
+  expectIndividualLetterHighlights,
+  screenshot,
+} from "./helpers";
 
 /**
- * Comprehensive E2E tests for the Sound feature.
+ * Comprehensive E2E tests for the Sound Display Transliteration feature.
  *
- * Run headed so a reviewer can watch the interactions:
- *   npx playwright test tests/sounds.spec.ts --headed
+ * Headed review:  npx playwright test tests/sounds.spec.ts --headed
+ * CI mode:        CI=true npx playwright test tests/sounds.spec.ts
  *
- * The tests use deliberate pauses (page.waitForTimeout) between steps so the
- * reviewer can visually follow along. Remove them for CI.
+ * Environment variables:
+ *   PLAYWRIGHT_BASE_URL  – app URL (default: http://127.0.0.1:3000)
+ *   TEST_STUDY_PATH      – study to test (default: a public Psalm 23 study)
+ *   TEST_PAUSE           – ms between steps (default: 600, 0 in CI)
+ *   TEST_EVIDENCE_DIR    – where to save screenshots
  */
 
-const publicStudyPath = "/study/d6ef7cl250emugaodqi0/view";
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                           */
-/* ------------------------------------------------------------------ */
-
-const PAUSE = 800; // ms between visual steps
-
-/** Wait for the study pane to fully render after navigation. */
-const waitForStudyLoad = async (page: Page) => {
-  await page.goto(publicStudyPath);
-  await page.waitForSelector('label[for="toggleLang"]', { timeout: 60_000 });
-};
-
-const inlineHighlights = (page: Page) =>
-  page.locator('#selaPassage [style*="background-color"]');
-
-const countInlineHighlights = (page: Page) => inlineHighlights(page).count();
-
-const clickDistributionChip = async (page: Page, chipLabel: string) => {
-  const buttons = page.locator("button");
-  const buttonCount = await buttons.count();
-
-  for (let index = 0; index < buttonCount; index += 1) {
-    const innerText = (await buttons.nth(index).innerText()).replace(/\s+/g, "");
-    if (innerText.startsWith(chipLabel)) {
-      await buttons.nth(index).click();
-      return;
-    }
-  }
-
-  throw new Error(`Unable to find chip starting with "${chipLabel}"`);
-};
-
-const switchToParallelMode = async (page: Page) => {
-  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
-  await expect(page.locator("select")).toBeVisible();
-};
-
-const selectDisplayMode = async (page: Page, label: "Hebrew OHB" | "Transliteration") => {
-  await page.locator("select").selectOption({ label });
-  await page.waitForTimeout(PAUSE);
-};
-
-const openSoundsTab = async (page: Page) => {
-  await page.getByRole("button", { name: "Sounds" }).click();
-  await page.waitForTimeout(PAUSE);
-};
-
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 /*  1 · Transliteration Display                                       */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 
 test.describe("Transliteration Display", () => {
+  test("dropdown has all 3 options per PDF spec", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+
+    const options = page.locator("select option");
+    await expect(options).toHaveCount(3);
+    await expect(options.nth(0)).toHaveText("English Gloss / Hebrew OHB");
+    await expect(options.nth(1)).toHaveText("English / Transliteration");
+    await expect(options.nth(2)).toHaveText("English Gloss / Hebrew Transliteration");
+    await screenshot(page, "dropdown-3-options");
+  });
+
   test("dropdown appears only in non-English modes and switches display", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
@@ -75,11 +58,11 @@ test.describe("Transliteration Display", () => {
     await switchToParallelMode(page);
     await page.waitForTimeout(PAUSE);
 
-    // Default option is "Hebrew OHB"
+    // Default option is "English Gloss / Hebrew OHB"
     await expect(page.locator("select")).toHaveValue("0");
 
-    // Select "Transliteration" — passage should show transliteration text
-    await selectDisplayMode(page, "Transliteration");
+    // Select "English / Transliteration" — passage should show transliteration text
+    await selectDisplayMode(page, "English / Transliteration");
     await expect(page.locator("select")).toHaveValue("1");
 
     // Verify transliteration text is rendered (dot-separated syllables)
@@ -87,10 +70,15 @@ test.describe("Transliteration Display", () => {
     await expect(passage).toContainText(/\w+\.\w+/); // e.g. "le.da.vid"
     await page.waitForTimeout(PAUSE);
 
-    // Switch back to "Hebrew OHB" — passage shows Hebrew characters
-    await selectDisplayMode(page, "Hebrew OHB");
+    // Switch back to "English Gloss / Hebrew OHB" — passage shows Hebrew characters
+    await selectDisplayMode(page, "English Gloss / Hebrew OHB");
     await expect(page.locator("select")).toHaveValue("0");
-    await page.waitForTimeout(PAUSE);
+
+    // Select "English Gloss / Hebrew Transliteration" — also shows transliteration
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
+    await expect(page.locator("select")).toHaveValue("2");
+    await expect(passage).toContainText(/\w+\.\w+/);
+    await screenshot(page, "transliteration-toggle");
   });
 
   test("Hebrew-only mode (א) also shows display dropdown", async ({ page }) => {
@@ -101,16 +89,16 @@ test.describe("Transliteration Display", () => {
     await page.waitForTimeout(PAUSE);
     await expect(page.locator("select")).toBeVisible();
 
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     const passage = page.locator("#selaPassage");
     await expect(passage).toContainText(/\w+\.\w+/);
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "hebrew-only-transliteration");
   });
 });
 
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 /*  2 · Hebrew Sound Distribution                                     */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 
 test.describe("Hebrew Sound Distribution", () => {
   const ALL_SOUND_LABELS = [
@@ -122,46 +110,37 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
-    // Sound Distribution section should be open by default
     await expect(
       page.locator("span", { hasText: "Hebrew Sound Distribution" }).first(),
     ).toBeVisible();
-    await page.waitForTimeout(PAUSE);
 
-    // Verify all 19 sound chips are present with a count badge
     for (const label of ALL_SOUND_LABELS) {
       const chip = page.locator("button.wordBlock", { hasText: label }).first();
       await expect(chip).toBeVisible();
 
-      // Each chip should display a numeric count
       const countBadge = chip.locator("span.rounded-full");
       await expect(countBadge).toBeVisible();
       const countText = await countBadge.innerText();
       expect(Number(countText)).toBeGreaterThanOrEqual(0);
     }
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "sound-chips-all-19");
   });
 
   test("chip selection toggles visual state", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
-    // Select "sh" chip — should get gold outline
     await clickDistributionChip(page, "sh");
-    await page.waitForTimeout(PAUSE);
-
     const shChip = page.locator("button.wordBlock", { hasText: "sh" }).first();
     await expect(shChip).toHaveClass(/outline-\[#FFC300\]/);
 
-    // Click again — should deselect
     await clickDistributionChip(page, "sh");
-    await page.waitForTimeout(PAUSE);
     await expect(shChip).not.toHaveClass(/outline-\[#FFC300\]/);
   });
 
@@ -169,287 +148,188 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
     const btn = page.getByRole("button", { name: "Smart Highlight" }).first();
     await expect(btn).toBeDisabled();
-    await page.waitForTimeout(PAUSE);
 
-    // Select a chip — button should become enabled
     await clickDistributionChip(page, "sh");
-    await page.waitForTimeout(PAUSE);
     await expect(btn).toBeEnabled();
+    await screenshot(page, "smart-highlight-enabled");
   });
 
   test("Smart Highlight applies inline highlights to transliteration", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
-    // Select "sh" chip
     await clickDistributionChip(page, "sh");
-    await page.waitForTimeout(PAUSE);
-
-    // No highlights yet
     expect(await countInlineHighlights(page)).toBe(0);
 
-    // Click Smart Highlight
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
-    // Button text changes to "Clear Highlight"
+    await clickSmartHighlight(page);
     await expect(page.getByRole("button", { name: "Clear Highlight" }).first()).toBeVisible();
 
-    // Inline highlights should appear in passage
-    const highlightCount = await countInlineHighlights(page);
-    expect(highlightCount).toBeGreaterThan(0);
-    await page.waitForTimeout(PAUSE);
-
-    // Verify highlights are on individual letter spans, NOT whole word boxes
-    const firstHighlight = inlineHighlights(page).first();
-    const highlightText = await firstHighlight.innerText();
-    // Individual sound segments are short (1-2 chars like "sh", "s", etc.)
-    expect(highlightText.length).toBeLessThanOrEqual(3);
-    await page.waitForTimeout(PAUSE);
+    await expectIndividualLetterHighlights(page);
+    await screenshot(page, "sound-highlight-transliteration");
   });
 
   test("Clear Highlight removes all inline highlights", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
+    await clickSmartHighlight(page);
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
 
-    // Click "Clear Highlight"
-    await page.getByRole("button", { name: "Clear Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
-    // Highlights removed
+    await clickSmartHighlight(page); // "Clear Highlight"
     expect(await countInlineHighlights(page)).toBe(0);
-    // Button text reverts
     await expect(page.getByRole("button", { name: "Smart Highlight" }).first()).toBeVisible();
-    await page.waitForTimeout(PAUSE);
   });
 
-  test("multiple sound chips can be selected and highlighted together", async ({ page }) => {
+  test("multiple sound chips produce multiple highlight colors", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
-    // Select two chips
     await clickDistributionChip(page, "sh");
-    await page.waitForTimeout(PAUSE);
     await clickDistributionChip(page, "s");
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
 
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
-    const highlightCount = await countInlineHighlights(page);
-    expect(highlightCount).toBeGreaterThan(0);
-
-    // Verify there are highlights with different background colors (two sounds = two colors)
-    const highlights = inlineHighlights(page);
-    const styles = new Set<string>();
-    const count = await highlights.count();
-    for (let i = 0; i < Math.min(count, 20); i++) {
-      const style = await highlights.nth(i).getAttribute("style");
-      if (style) {
-        const match = style.match(/background-color:\s*([^;]+)/);
-        if (match) styles.add(match[1].trim());
-      }
-    }
-    expect(styles.size).toBeGreaterThanOrEqual(2);
-    await page.waitForTimeout(PAUSE);
+    const colors = await collectHighlightColors(page);
+    expect(colors.size).toBeGreaterThanOrEqual(2);
+    await screenshot(page, "sound-multiple-chips");
   });
 
   test("sound highlights also apply in Hebrew OHB view", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Hebrew OHB");
+    await selectDisplayMode(page, "English Gloss / Hebrew OHB");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
 
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
-    // Highlights should appear on Hebrew letters
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "sound-highlight-hebrew");
   });
 });
 
-/* ------------------------------------------------------------------ */
-/*  3 · Hebrew Letter Distribution                                    */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
+/*  3 · Hebrew Letters Distribution                                    */
+/* ================================================================== */
 
-test.describe("Hebrew Letter Distribution", () => {
+test.describe("Hebrew Letters Distribution", () => {
   const SAMPLE_LETTER_LABELS = ["א", "ב", "ג", "ד", "ה", "ו", "ל", "מ", "ר", "שׁ", "ת"];
 
   test("shows Hebrew letter chips with counts", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Hebrew OHB");
+    await selectDisplayMode(page, "English Gloss / Hebrew OHB");
     await openSoundsTab(page);
 
-    // Open Letter Distribution section
-    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
-    await page.waitForTimeout(PAUSE);
+    await openDistributionSection(page, "Hebrew Letters Distribution");
 
-    // Verify sample letter chips are visible with counts
     for (const label of SAMPLE_LETTER_LABELS) {
       const chip = page.locator("button.wordBlock", { hasText: label }).first();
       await expect(chip).toBeVisible();
     }
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "letter-chips");
   });
 
   test("letter highlighting works on Hebrew text", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Hebrew OHB");
+    await selectDisplayMode(page, "English Gloss / Hebrew OHB");
     await openSoundsTab(page);
 
-    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
-    await page.waitForTimeout(PAUSE);
-
-    // Select shin (שׁ)
+    await openDistributionSection(page, "Hebrew Letters Distribution");
     await clickDistributionChip(page, "שׁ");
-    await page.waitForTimeout(PAUSE);
 
     expect(await countInlineHighlights(page)).toBe(0);
-
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
 
     await expect(page.getByRole("button", { name: "Clear Highlight" }).first()).toBeVisible();
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "letter-highlight-hebrew");
   });
 
   test("letter chip selection toggles independently", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Hebrew OHB");
+    await selectDisplayMode(page, "English Gloss / Hebrew OHB");
     await openSoundsTab(page);
 
-    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
-    await page.waitForTimeout(PAUSE);
-
-    // Select two letters
+    await openDistributionSection(page, "Hebrew Letters Distribution");
     await clickDistributionChip(page, "ל");
-    await page.waitForTimeout(PAUSE);
     await clickDistributionChip(page, "מ");
-    await page.waitForTimeout(PAUSE);
-
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
 
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
 
-    // Deselect one — highlights update
     await clickDistributionChip(page, "ל");
-    await page.waitForTimeout(PAUSE);
-
-    // Still some highlights for "מ"
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
-    await page.waitForTimeout(PAUSE);
   });
 });
 
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 /*  4 · Smart Highlight – Only Selected Chips (NEW LOGIC)             */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 
 test.describe("Smart Highlight – Selection Logic", () => {
   test("only selected chips are highlighted, not all", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
-    // Select only "d" chip
     await clickDistributionChip(page, "d");
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
 
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
-    // Only "d" sound should be highlighted — all highlights should share the same color
-    const highlights = inlineHighlights(page);
-    const count = await highlights.count();
-    expect(count).toBeGreaterThan(0);
-
-    const colors = new Set<string>();
-    for (let i = 0; i < count; i++) {
-      const style = await highlights.nth(i).getAttribute("style");
-      if (style) {
-        const match = style.match(/background-color:\s*([^;]+)/);
-        if (match) colors.add(match[1].trim());
-      }
-    }
-    // Single chip selected → single highlight color
+    const colors = await collectHighlightColors(page);
     expect(colors.size).toBe(1);
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "only-selected-chip");
   });
 
   test("sound and letter highlighting are mutually exclusive", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Hebrew OHB");
+    await selectDisplayMode(page, "English Gloss / Hebrew OHB");
     await openSoundsTab(page);
 
-    // Activate sound highlighting first
+    // Activate sound highlighting
     await clickDistributionChip(page, "sh");
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
 
-    // Switch to Letter Distribution and activate letter highlighting
-    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
-    await page.waitForTimeout(PAUSE);
-
+    // Switch to letters and activate
+    await openDistributionSection(page, "Hebrew Letters Distribution");
     await clickDistributionChip(page, "ל");
-    await page.waitForTimeout(PAUSE);
+    await clickSmartHighlight(page);
 
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
-    // Letter highlighting is active — sound highlighting should be auto-cleared
-    await expect(page.getByRole("button", { name: "Clear Highlight" }).first()).toBeVisible();
-
-    // Switch back to Sound Distribution
-    await page.getByRole("button", { name: /Hebrew Sound Distribution/ }).click();
-    await page.waitForTimeout(PAUSE);
-
-    // Sound highlight button should NOT show "Clear Highlight"
+    // Go back to sounds — should show "Smart Highlight" (not "Clear")
+    await openDistributionSection(page, "Hebrew Sound Distribution");
     await expect(page.getByRole("button", { name: "Smart Highlight" }).first()).toBeVisible();
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "mutually-exclusive");
   });
 });
 
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 /*  5 · Info Tooltip                                                  */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 
 test.describe("Info Tooltip", () => {
   test("tooltip with correct description is present", async ({ page }) => {
@@ -460,40 +340,53 @@ test.describe("Info Tooltip", () => {
 
     const tooltip = page.locator('span[title*="Different Hebrew letters"]');
     await expect(tooltip).toBeVisible();
-    await page.waitForTimeout(PAUSE);
 
     const titleAttr = await tooltip.getAttribute("title");
-    expect(titleAttr).toContain("sound patterns");
-    expect(titleAttr).toContain("transliteration");
+    // Verify the FULL tooltip text matches PDF spec verbatim
+    expect(titleAttr).toContain("helps you detect sound patterns and rhymes");
+    expect(titleAttr).toContain("based on how words are heard, not how they are written");
+    expect(titleAttr).toContain("not in the default English display");
+    await screenshot(page, "info-tooltip");
+  });
+
+  test("tooltip popup appears on hover", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await openSoundsTab(page);
+
+    const tooltipTrigger = page.locator('span[title*="Different Hebrew letters"]');
+    await tooltipTrigger.hover();
     await page.waitForTimeout(PAUSE);
+
+    // The styled popup should appear
+    const popup = page.locator(".shadow-lg", { hasText: "sound patterns and rhymes" });
+    await expect(popup).toBeVisible();
+    await screenshot(page, "info-tooltip-popup");
   });
 });
 
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 /*  6 · No Persistence (browsing-only filter)                         */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
 
 test.describe("No Persistence", () => {
   test("highlights reset after page reload", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "Transliteration");
+    await selectDisplayMode(page, "English / Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
-    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
-    await page.waitForTimeout(PAUSE);
-
+    await clickSmartHighlight(page);
     expect(await countInlineHighlights(page)).toBeGreaterThan(0);
 
-    // Reload the page
     await page.reload();
     await page.waitForSelector('label[for="toggleLang"]', { timeout: 60_000 });
 
-    // After reload, no highlights should be present (state is not persisted)
     expect(await countInlineHighlights(page)).toBe(0);
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "no-persistence-after-reload");
   });
 
   test("footer disclaimer text is visible", async ({ page }) => {
@@ -505,6 +398,6 @@ test.describe("No Persistence", () => {
     await expect(
       page.locator("text=Individual-letter highlights stay in the browser"),
     ).toBeVisible();
-    await page.waitForTimeout(PAUSE);
+    await screenshot(page, "disclaimer-text");
   });
 });

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -1,14 +1,35 @@
 import { expect, test, type Page } from "@playwright/test";
 
+/**
+ * Comprehensive E2E tests for the Sound feature.
+ *
+ * Run headed so a reviewer can watch the interactions:
+ *   npx playwright test tests/sounds.spec.ts --headed
+ *
+ * The tests use deliberate pauses (page.waitForTimeout) between steps so the
+ * reviewer can visually follow along. Remove them for CI.
+ */
+
 const publicStudyPath = "/study/d6ef7cl250emugaodqi0/view";
 
-const countInlineHighlights = async (page: Page) =>
-  page.locator('#selaPassage [style*="background-color"]').count();
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
 
-const clickDistributionChip = async (
-  page: Page,
-  chipLabel: string,
-) => {
+const PAUSE = 800; // ms between visual steps
+
+/** Wait for the study pane to fully render after navigation. */
+const waitForStudyLoad = async (page: Page) => {
+  await page.goto(publicStudyPath);
+  await page.waitForSelector('label[for="toggleLang"]', { timeout: 60_000 });
+};
+
+const inlineHighlights = (page: Page) =>
+  page.locator('#selaPassage [style*="background-color"]');
+
+const countInlineHighlights = (page: Page) => inlineHighlights(page).count();
+
+const clickDistributionChip = async (page: Page, chipLabel: string) => {
   const buttons = page.locator("button");
   const buttonCount = await buttons.count();
 
@@ -23,39 +44,467 @@ const clickDistributionChip = async (
   throw new Error(`Unable to find chip starting with "${chipLabel}"`);
 };
 
-test("public study view supports transliteration sound highlighting", async ({ page }) => {
-  await page.goto(publicStudyPath);
-
+const switchToParallelMode = async (page: Page) => {
   await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
   await expect(page.locator("select")).toBeVisible();
-  await page.locator("select").selectOption({ label: "Transliteration" });
+};
 
+const selectDisplayMode = async (page: Page, label: "Hebrew OHB" | "Transliteration") => {
+  await page.locator("select").selectOption({ label });
+  await page.waitForTimeout(PAUSE);
+};
+
+const openSoundsTab = async (page: Page) => {
   await page.getByRole("button", { name: "Sounds" }).click();
-  await clickDistributionChip(page, "sh");
+  await page.waitForTimeout(PAUSE);
+};
 
-  expect(await countInlineHighlights(page)).toBe(0);
+/* ------------------------------------------------------------------ */
+/*  1 · Transliteration Display                                       */
+/* ------------------------------------------------------------------ */
 
-  await page.getByRole("button", { name: "Smart Highlight" }).click();
+test.describe("Transliteration Display", () => {
+  test("dropdown appears only in non-English modes and switches display", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
 
-  await expect(page.getByRole("button", { name: "Clear Highlight" })).toBeVisible();
-  expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+    // English mode — no display dropdown
+    await expect(page.locator("select")).not.toBeVisible();
+
+    // Switch to Parallel (Aא) — dropdown should appear
+    await switchToParallelMode(page);
+    await page.waitForTimeout(PAUSE);
+
+    // Default option is "Hebrew OHB"
+    await expect(page.locator("select")).toHaveValue("0");
+
+    // Select "Transliteration" — passage should show transliteration text
+    await selectDisplayMode(page, "Transliteration");
+    await expect(page.locator("select")).toHaveValue("1");
+
+    // Verify transliteration text is rendered (dot-separated syllables)
+    const passage = page.locator("#selaPassage");
+    await expect(passage).toContainText(/\w+\.\w+/); // e.g. "le.da.vid"
+    await page.waitForTimeout(PAUSE);
+
+    // Switch back to "Hebrew OHB" — passage shows Hebrew characters
+    await selectDisplayMode(page, "Hebrew OHB");
+    await expect(page.locator("select")).toHaveValue("0");
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("Hebrew-only mode (א) also shows display dropdown", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+
+    await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
+    await page.waitForTimeout(PAUSE);
+    await expect(page.locator("select")).toBeVisible();
+
+    await selectDisplayMode(page, "Transliteration");
+    const passage = page.locator("#selaPassage");
+    await expect(passage).toContainText(/\w+\.\w+/);
+    await page.waitForTimeout(PAUSE);
+  });
 });
 
-test("public study view supports Hebrew letter highlighting", async ({ page }) => {
-  await page.goto(publicStudyPath);
+/* ------------------------------------------------------------------ */
+/*  2 · Hebrew Sound Distribution                                     */
+/* ------------------------------------------------------------------ */
 
-  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
-  await expect(page.locator("select")).toBeVisible();
-  await page.locator("select").selectOption({ label: "Hebrew OHB" });
+test.describe("Hebrew Sound Distribution", () => {
+  const ALL_SOUND_LABELS = [
+    "s", "sh", "ts", "z", "kh/ch", "k/q", "g", "h",
+    "d", "t", "n", "m", "b", "v", "p", "f", "l", "r", "y",
+  ];
 
-  await page.getByRole("button", { name: "Sounds" }).click();
-  await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
-  await clickDistributionChip(page, "שׁ");
+  test("shows all 19 sound chips with counts", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
 
-  expect(await countInlineHighlights(page)).toBe(0);
+    // Sound Distribution section should be open by default
+    await expect(
+      page.locator("span", { hasText: "Hebrew Sound Distribution" }).first(),
+    ).toBeVisible();
+    await page.waitForTimeout(PAUSE);
 
-  await page.getByRole("button", { name: "Smart Highlight" }).click();
+    // Verify all 19 sound chips are present with a count badge
+    for (const label of ALL_SOUND_LABELS) {
+      const chip = page.locator("button.wordBlock", { hasText: label }).first();
+      await expect(chip).toBeVisible();
 
-  await expect(page.getByRole("button", { name: "Clear Highlight" })).toBeVisible();
-  expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+      // Each chip should display a numeric count
+      const countBadge = chip.locator("span.rounded-full");
+      await expect(countBadge).toBeVisible();
+      const countText = await countBadge.innerText();
+      expect(Number(countText)).toBeGreaterThanOrEqual(0);
+    }
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("chip selection toggles visual state", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    // Select "sh" chip — should get gold outline
+    await clickDistributionChip(page, "sh");
+    await page.waitForTimeout(PAUSE);
+
+    const shChip = page.locator("button.wordBlock", { hasText: "sh" }).first();
+    await expect(shChip).toHaveClass(/outline-\[#FFC300\]/);
+
+    // Click again — should deselect
+    await clickDistributionChip(page, "sh");
+    await page.waitForTimeout(PAUSE);
+    await expect(shChip).not.toHaveClass(/outline-\[#FFC300\]/);
+  });
+
+  test("Smart Highlight button is disabled when no chips selected", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    const btn = page.getByRole("button", { name: "Smart Highlight" }).first();
+    await expect(btn).toBeDisabled();
+    await page.waitForTimeout(PAUSE);
+
+    // Select a chip — button should become enabled
+    await clickDistributionChip(page, "sh");
+    await page.waitForTimeout(PAUSE);
+    await expect(btn).toBeEnabled();
+  });
+
+  test("Smart Highlight applies inline highlights to transliteration", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    // Select "sh" chip
+    await clickDistributionChip(page, "sh");
+    await page.waitForTimeout(PAUSE);
+
+    // No highlights yet
+    expect(await countInlineHighlights(page)).toBe(0);
+
+    // Click Smart Highlight
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    // Button text changes to "Clear Highlight"
+    await expect(page.getByRole("button", { name: "Clear Highlight" }).first()).toBeVisible();
+
+    // Inline highlights should appear in passage
+    const highlightCount = await countInlineHighlights(page);
+    expect(highlightCount).toBeGreaterThan(0);
+    await page.waitForTimeout(PAUSE);
+
+    // Verify highlights are on individual letter spans, NOT whole word boxes
+    const firstHighlight = inlineHighlights(page).first();
+    const highlightText = await firstHighlight.innerText();
+    // Individual sound segments are short (1-2 chars like "sh", "s", etc.)
+    expect(highlightText.length).toBeLessThanOrEqual(3);
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("Clear Highlight removes all inline highlights", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    await clickDistributionChip(page, "sh");
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+
+    // Click "Clear Highlight"
+    await page.getByRole("button", { name: "Clear Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    // Highlights removed
+    expect(await countInlineHighlights(page)).toBe(0);
+    // Button text reverts
+    await expect(page.getByRole("button", { name: "Smart Highlight" }).first()).toBeVisible();
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("multiple sound chips can be selected and highlighted together", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    // Select two chips
+    await clickDistributionChip(page, "sh");
+    await page.waitForTimeout(PAUSE);
+    await clickDistributionChip(page, "s");
+    await page.waitForTimeout(PAUSE);
+
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    const highlightCount = await countInlineHighlights(page);
+    expect(highlightCount).toBeGreaterThan(0);
+
+    // Verify there are highlights with different background colors (two sounds = two colors)
+    const highlights = inlineHighlights(page);
+    const styles = new Set<string>();
+    const count = await highlights.count();
+    for (let i = 0; i < Math.min(count, 20); i++) {
+      const style = await highlights.nth(i).getAttribute("style");
+      if (style) {
+        const match = style.match(/background-color:\s*([^;]+)/);
+        if (match) styles.add(match[1].trim());
+      }
+    }
+    expect(styles.size).toBeGreaterThanOrEqual(2);
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("sound highlights also apply in Hebrew OHB view", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Hebrew OHB");
+    await openSoundsTab(page);
+
+    await clickDistributionChip(page, "sh");
+    await page.waitForTimeout(PAUSE);
+
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    // Highlights should appear on Hebrew letters
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+    await page.waitForTimeout(PAUSE);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  3 · Hebrew Letter Distribution                                    */
+/* ------------------------------------------------------------------ */
+
+test.describe("Hebrew Letter Distribution", () => {
+  const SAMPLE_LETTER_LABELS = ["א", "ב", "ג", "ד", "ה", "ו", "ל", "מ", "ר", "שׁ", "ת"];
+
+  test("shows Hebrew letter chips with counts", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Hebrew OHB");
+    await openSoundsTab(page);
+
+    // Open Letter Distribution section
+    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
+    await page.waitForTimeout(PAUSE);
+
+    // Verify sample letter chips are visible with counts
+    for (const label of SAMPLE_LETTER_LABELS) {
+      const chip = page.locator("button.wordBlock", { hasText: label }).first();
+      await expect(chip).toBeVisible();
+    }
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("letter highlighting works on Hebrew text", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Hebrew OHB");
+    await openSoundsTab(page);
+
+    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
+    await page.waitForTimeout(PAUSE);
+
+    // Select shin (שׁ)
+    await clickDistributionChip(page, "שׁ");
+    await page.waitForTimeout(PAUSE);
+
+    expect(await countInlineHighlights(page)).toBe(0);
+
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    await expect(page.getByRole("button", { name: "Clear Highlight" }).first()).toBeVisible();
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("letter chip selection toggles independently", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Hebrew OHB");
+    await openSoundsTab(page);
+
+    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
+    await page.waitForTimeout(PAUSE);
+
+    // Select two letters
+    await clickDistributionChip(page, "ל");
+    await page.waitForTimeout(PAUSE);
+    await clickDistributionChip(page, "מ");
+    await page.waitForTimeout(PAUSE);
+
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+
+    // Deselect one — highlights update
+    await clickDistributionChip(page, "ל");
+    await page.waitForTimeout(PAUSE);
+
+    // Still some highlights for "מ"
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+    await page.waitForTimeout(PAUSE);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  4 · Smart Highlight – Only Selected Chips (NEW LOGIC)             */
+/* ------------------------------------------------------------------ */
+
+test.describe("Smart Highlight – Selection Logic", () => {
+  test("only selected chips are highlighted, not all", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    // Select only "d" chip
+    await clickDistributionChip(page, "d");
+    await page.waitForTimeout(PAUSE);
+
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    // Only "d" sound should be highlighted — all highlights should share the same color
+    const highlights = inlineHighlights(page);
+    const count = await highlights.count();
+    expect(count).toBeGreaterThan(0);
+
+    const colors = new Set<string>();
+    for (let i = 0; i < count; i++) {
+      const style = await highlights.nth(i).getAttribute("style");
+      if (style) {
+        const match = style.match(/background-color:\s*([^;]+)/);
+        if (match) colors.add(match[1].trim());
+      }
+    }
+    // Single chip selected → single highlight color
+    expect(colors.size).toBe(1);
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("sound and letter highlighting are mutually exclusive", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Hebrew OHB");
+    await openSoundsTab(page);
+
+    // Activate sound highlighting first
+    await clickDistributionChip(page, "sh");
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+
+    // Switch to Letter Distribution and activate letter highlighting
+    await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
+    await page.waitForTimeout(PAUSE);
+
+    await clickDistributionChip(page, "ל");
+    await page.waitForTimeout(PAUSE);
+
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    // Letter highlighting is active — sound highlighting should be auto-cleared
+    await expect(page.getByRole("button", { name: "Clear Highlight" }).first()).toBeVisible();
+
+    // Switch back to Sound Distribution
+    await page.getByRole("button", { name: /Hebrew Sound Distribution/ }).click();
+    await page.waitForTimeout(PAUSE);
+
+    // Sound highlight button should NOT show "Clear Highlight"
+    await expect(page.getByRole("button", { name: "Smart Highlight" }).first()).toBeVisible();
+    await page.waitForTimeout(PAUSE);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  5 · Info Tooltip                                                  */
+/* ------------------------------------------------------------------ */
+
+test.describe("Info Tooltip", () => {
+  test("tooltip with correct description is present", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await openSoundsTab(page);
+
+    const tooltip = page.locator('span[title*="Different Hebrew letters"]');
+    await expect(tooltip).toBeVisible();
+    await page.waitForTimeout(PAUSE);
+
+    const titleAttr = await tooltip.getAttribute("title");
+    expect(titleAttr).toContain("sound patterns");
+    expect(titleAttr).toContain("transliteration");
+    await page.waitForTimeout(PAUSE);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  6 · No Persistence (browsing-only filter)                         */
+/* ------------------------------------------------------------------ */
+
+test.describe("No Persistence", () => {
+  test("highlights reset after page reload", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await selectDisplayMode(page, "Transliteration");
+    await openSoundsTab(page);
+
+    await clickDistributionChip(page, "sh");
+    await page.getByRole("button", { name: "Smart Highlight" }).first().click();
+    await page.waitForTimeout(PAUSE);
+
+    expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+
+    // Reload the page
+    await page.reload();
+    await page.waitForSelector('label[for="toggleLang"]', { timeout: 60_000 });
+
+    // After reload, no highlights should be present (state is not persisted)
+    expect(await countInlineHighlights(page)).toBe(0);
+    await page.waitForTimeout(PAUSE);
+  });
+
+  test("footer disclaimer text is visible", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+    await openSoundsTab(page);
+
+    await expect(
+      page.locator("text=Individual-letter highlights stay in the browser"),
+    ).toBeVisible();
+    await page.waitForTimeout(PAUSE);
+  });
 });

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -34,7 +34,7 @@ import {
 /* ================================================================== */
 
 test.describe("Transliteration Display", () => {
-  test("dropdown popover has 3 options in Parallel mode matching PDF page 4", async ({ page }) => {
+  test("dropdown popover has 2 options in Parallel mode matching PDF page 4", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
@@ -44,12 +44,11 @@ test.describe("Transliteration Display", () => {
     await chevron.click();
     await page.waitForTimeout(PAUSE);
 
-    // Popover should show 3 options (PDF page 4)
+    // Popover should show 2 options (PDF page 4)
     const options = page.locator('.shadow-lg button');
-    await expect(options).toHaveCount(3);
+    await expect(options).toHaveCount(2);
     await expect(options.nth(0)).toContainText("English Gloss / Hebrew OHB");
-    await expect(options.nth(1)).toContainText("English / Transliteration");
-    await expect(options.nth(2)).toContainText("English Gloss / Hebrew Transliteration");
+    await expect(options.nth(1)).toContainText("English Gloss / Hebrew Transliteration");
     await screenshot(page, "dropdown-options");
   });
 

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const publicStudyPath = "/study/d6ef7cl250emugaodqi0/view";
+
+const countInlineHighlights = async (page: Page) =>
+  page.locator('#selaPassage [style*="background-color"]').count();
+
+const clickDistributionChip = async (
+  page: Page,
+  chipLabel: string,
+) => {
+  const buttons = page.locator("button");
+  const buttonCount = await buttons.count();
+
+  for (let index = 0; index < buttonCount; index += 1) {
+    const innerText = (await buttons.nth(index).innerText()).replace(/\s+/g, "");
+    if (innerText.startsWith(chipLabel)) {
+      await buttons.nth(index).click();
+      return;
+    }
+  }
+
+  throw new Error(`Unable to find chip starting with "${chipLabel}"`);
+};
+
+test("public study view supports transliteration sound highlighting", async ({ page }) => {
+  await page.goto(publicStudyPath);
+
+  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
+  await expect(page.locator("select")).toBeVisible();
+  await page.locator("select").selectOption({ label: "Transliteration" });
+
+  await page.getByRole("button", { name: "Sounds" }).click();
+  await clickDistributionChip(page, "sh");
+
+  expect(await countInlineHighlights(page)).toBe(0);
+
+  await page.getByRole("button", { name: "Smart Highlight" }).click();
+
+  await expect(page.getByRole("button", { name: "Clear Highlight" })).toBeVisible();
+  expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+});
+
+test("public study view supports Hebrew letter highlighting", async ({ page }) => {
+  await page.goto(publicStudyPath);
+
+  await page.locator('label[for="toggleLang"] span', { hasText: "Aא" }).first().click();
+  await expect(page.locator("select")).toBeVisible();
+  await page.locator("select").selectOption({ label: "Hebrew OHB" });
+
+  await page.getByRole("button", { name: "Sounds" }).click();
+  await page.getByRole("button", { name: /Hebrew Letter Distribution/ }).click();
+  await clickDistributionChip(page, "שׁ");
+
+  expect(await countInlineHighlights(page)).toBe(0);
+
+  await page.getByRole("button", { name: "Smart Highlight" }).click();
+
+  await expect(page.getByRole("button", { name: "Clear Highlight" })).toBeVisible();
+  expect(await countInlineHighlights(page)).toBeGreaterThan(0);
+});

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -34,62 +34,54 @@ import {
 /* ================================================================== */
 
 test.describe("Transliteration Display", () => {
-  test("dropdown has all 3 options per PDF spec", async ({ page }) => {
+  test("dropdown popover has 2 options matching PDF spec", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
 
-    const options = page.locator("select option");
-    await expect(options).toHaveCount(3);
-    await expect(options.nth(0)).toHaveText("English Gloss / Hebrew OHB");
-    await expect(options.nth(1)).toHaveText("English / Transliteration");
-    await expect(options.nth(2)).toHaveText("English Gloss / Hebrew Transliteration");
-    await screenshot(page, "dropdown-3-options");
-  });
-
-  test("dropdown appears only in non-English modes and switches display", async ({ page }) => {
-    test.slow();
-    await waitForStudyLoad(page);
-
-    // English mode — no display dropdown
-    await expect(page.locator("select")).not.toBeVisible();
-
-    // Switch to Parallel (Aא) — dropdown should appear
-    await switchToParallelMode(page);
+    // Click the chevron to open dropdown
+    const chevron = page.locator('label[for="toggleLang"] svg').first();
+    await chevron.click();
     await page.waitForTimeout(PAUSE);
 
-    // Default option is "English Gloss / Hebrew OHB"
-    await expect(page.locator("select")).toHaveValue("0");
+    // Popover should show 2 options
+    const options = page.locator('.shadow-lg button');
+    await expect(options).toHaveCount(2);
+    await expect(options.nth(0)).toContainText("English Gloss / Hebrew OHB");
+    await expect(options.nth(1)).toContainText("English Gloss / Hebrew Transliteration");
+    await screenshot(page, "dropdown-options");
+  });
 
-    // Select "English / Transliteration" — passage should show transliteration text
-    await selectDisplayMode(page, "English / Transliteration");
-    await expect(page.locator("select")).toHaveValue("1");
+  test("dropdown switches between Hebrew OHB and Transliteration", async ({ page }) => {
+    test.slow();
+    await waitForStudyLoad(page);
+    await switchToParallelMode(page);
+
+    // Select transliteration
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
 
     // Verify transliteration text is rendered (dot-separated syllables)
     const passage = page.locator("#selaPassage");
     await expect(passage).toContainText(/\w+\.\w+/); // e.g. "le.da.vid"
     await page.waitForTimeout(PAUSE);
 
-    // Switch back to "English Gloss / Hebrew OHB" — passage shows Hebrew characters
+    // Switch back to Hebrew OHB
     await selectDisplayMode(page, "English Gloss / Hebrew OHB");
-    await expect(page.locator("select")).toHaveValue("0");
-
-    // Select "English Gloss / Hebrew Transliteration" — also shows transliteration
-    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
-    await expect(page.locator("select")).toHaveValue("2");
-    await expect(passage).toContainText(/\w+\.\w+/);
     await screenshot(page, "transliteration-toggle");
   });
 
-  test("Hebrew-only mode (א) also shows display dropdown", async ({ page }) => {
+  test("Hebrew-only mode (א) also shows dropdown chevron", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
 
     await page.locator('label[for="toggleLang"] span').filter({ hasText: /^א$/ }).click();
     await page.waitForTimeout(PAUSE);
-    await expect(page.locator("select")).toBeVisible();
 
-    await selectDisplayMode(page, "English / Transliteration");
+    // Chevron should appear on the א button
+    const chevron = page.locator('label[for="toggleLang"] svg').first();
+    await expect(chevron).toBeVisible();
+
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     const passage = page.locator("#selaPassage");
     await expect(passage).toContainText(/\w+\.\w+/);
     await screenshot(page, "hebrew-only-transliteration");
@@ -110,7 +102,7 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await expect(
@@ -133,7 +125,7 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
@@ -148,7 +140,7 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     const btn = page.getByRole("button", { name: "Smart Highlight" }).first();
@@ -163,7 +155,7 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
@@ -180,7 +172,7 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
@@ -196,7 +188,7 @@ test.describe("Hebrew Sound Distribution", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");
@@ -292,7 +284,7 @@ test.describe("Smart Highlight – Selection Logic", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "d");
@@ -375,7 +367,7 @@ test.describe("No Persistence", () => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
-    await selectDisplayMode(page, "English / Transliteration");
+    await selectDisplayMode(page, "English Gloss / Hebrew Transliteration");
     await openSoundsTab(page);
 
     await clickDistributionChip(page, "sh");

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -34,7 +34,7 @@ import {
 /* ================================================================== */
 
 test.describe("Transliteration Display", () => {
-  test("dropdown popover has 2 options matching PDF spec", async ({ page }) => {
+  test("dropdown popover has 3 options in Parallel mode matching PDF page 4", async ({ page }) => {
     test.slow();
     await waitForStudyLoad(page);
     await switchToParallelMode(page);
@@ -44,11 +44,12 @@ test.describe("Transliteration Display", () => {
     await chevron.click();
     await page.waitForTimeout(PAUSE);
 
-    // Popover should show 2 options
+    // Popover should show 3 options (PDF page 4)
     const options = page.locator('.shadow-lg button');
-    await expect(options).toHaveCount(2);
+    await expect(options).toHaveCount(3);
     await expect(options.nth(0)).toContainText("English Gloss / Hebrew OHB");
-    await expect(options.nth(1)).toContainText("English Gloss / Hebrew Transliteration");
+    await expect(options.nth(1)).toContainText("English / Transliteration");
+    await expect(options.nth(2)).toContainText("English Gloss / Hebrew Transliteration");
     await screenshot(page, "dropdown-options");
   });
 

--- a/tests/unit/hebrewHighlights.test.ts
+++ b/tests/unit/hebrewHighlights.test.ts
@@ -1,0 +1,636 @@
+import { describe, it, expect } from "vitest";
+import {
+  SOUND_CHIPS,
+  LETTER_CHIPS,
+  LETTER_CHIP_GROUPS,
+  SOUND_CHIP_MAP,
+  LETTER_CHIP_MAP,
+  splitTransliterationSegments,
+  splitHebrewClusters,
+  countSoundOccurrences,
+  countLetterOccurrences,
+  wordContainsSound,
+  wordContainsLetter,
+  buildHighlightedTransliterationSegments,
+  buildHighlightedHebrewSegments,
+} from "@/lib/hebrewHighlights";
+import type { WordProps } from "@/lib/data";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Build a minimal WordProps for testing. */
+const makeWord = (opts: {
+  hebrew?: string;
+  transliteration?: string;
+  wlcWord?: string;
+}): WordProps =>
+  ({
+    wordId: 1,
+    stanzaId: 1,
+    stropheId: 1,
+    lineId: 1,
+    chapter: 23,
+    verse: 1,
+    strongNumber: 1,
+    wlcWord: opts.wlcWord ?? "",
+    gloss: "test",
+    ETCBCgloss: undefined,
+    metadata: {},
+    newLine: false,
+    showVerseNum: false,
+    firstWordInStrophe: false,
+    firstStropheInStanza: false,
+    lastStropheInStanza: false,
+    motifData: { lemma: "", relatedStrongNums: undefined, categories: [] },
+    wordInformation: opts.hebrew || opts.transliteration
+      ? {
+          hebrew: opts.hebrew ?? "",
+          transliteration: opts.transliteration ?? "",
+          gloss: "",
+          morphology: "",
+          strongsNumber: "",
+          meaning: "",
+        }
+      : undefined,
+  }) as WordProps;
+
+/* ================================================================== */
+/*  1 · SOUND_CHIPS definitions                                       */
+/* ================================================================== */
+
+describe("SOUND_CHIPS definitions", () => {
+  it("contains exactly 19 sound chips", () => {
+    expect(SOUND_CHIPS).toHaveLength(19);
+  });
+
+  it("has the correct sound IDs", () => {
+    const ids = SOUND_CHIPS.map((c) => c.id);
+    expect(ids).toEqual([
+      "s", "sh", "ts", "z", "kh-ch", "k-q",
+      "g", "h", "d", "t", "n", "m",
+      "b", "v", "p", "f", "l", "r", "y",
+    ]);
+  });
+
+  it("has the correct labels", () => {
+    const labels = SOUND_CHIPS.map((c) => c.label);
+    expect(labels).toEqual([
+      "s", "sh", "ts", "z", "kh/ch", "k/q",
+      "g", "h", "d", "t", "n", "m",
+      "b", "v", "p", "f", "l", "r", "y",
+    ]);
+  });
+
+  it("each chip has a palette with fill, border, text", () => {
+    for (const chip of SOUND_CHIPS) {
+      expect(chip.palette.fill).toBeDefined();
+      expect(chip.palette.border).toBeDefined();
+      expect(chip.palette.text).toBeDefined();
+    }
+  });
+
+  it("SOUND_CHIP_MAP can look up every chip by id", () => {
+    for (const chip of SOUND_CHIPS) {
+      expect(SOUND_CHIP_MAP.get(chip.id)).toBe(chip);
+    }
+  });
+});
+
+/* ================================================================== */
+/*  2 · LETTER_CHIPS definitions                                      */
+/* ================================================================== */
+
+describe("LETTER_CHIPS definitions", () => {
+  it("contains 27 letter chips (22 base + 5 final forms)", () => {
+    expect(LETTER_CHIPS).toHaveLength(27);
+  });
+
+  it("includes all base Hebrew letters", () => {
+    const labels = LETTER_CHIPS.map((c) => c.label);
+    const baseLetters = [
+      "א", "ב", "ג", "ד", "ה", "ו", "ז", "ח", "ט", "י",
+      "כ", "ל", "מ", "נ", "ס", "ע", "פ", "צ", "ק", "ר", "ת",
+    ];
+    for (const letter of baseLetters) {
+      expect(labels).toContain(letter);
+    }
+  });
+
+  it("includes final forms: ך, ם, ן, ץ", () => {
+    const labels = LETTER_CHIPS.map((c) => c.label);
+    expect(labels).toContain("ך");
+    expect(labels).toContain("ם");
+    expect(labels).toContain("ן");
+    expect(labels).toContain("ץ");
+  });
+
+  it("includes sin (שׂ) and shin (שׁ) separately", () => {
+    const labels = LETTER_CHIPS.map((c) => c.label);
+    expect(labels).toContain("שׂ");
+    expect(labels).toContain("שׁ");
+  });
+
+  it("LETTER_CHIP_MAP can look up every chip by id", () => {
+    for (const chip of LETTER_CHIPS) {
+      expect(LETTER_CHIP_MAP.get(chip.id)).toBe(chip);
+    }
+  });
+});
+
+/* ================================================================== */
+/*  3 · splitTransliterationSegments                                  */
+/* ================================================================== */
+
+describe("splitTransliterationSegments", () => {
+  it("splits simple transliteration into sound segments", () => {
+    const segments = splitTransliterationSegments("le.da.vid");
+    const soundSegments = segments.filter((s) => s.highlightId);
+    expect(soundSegments.map((s) => s.highlightId)).toEqual(["l", "d", "v", "d"]);
+  });
+
+  it("correctly identifies 'sh' as a two-letter pattern", () => {
+    const segments = splitTransliterationSegments("she.mo");
+    const shSegment = segments.find((s) => s.highlightId === "sh");
+    expect(shSegment).toBeDefined();
+    expect(shSegment!.text).toBe("sh");
+  });
+
+  it("correctly identifies 'kh' as kh-ch sound", () => {
+    const segments = splitTransliterationSegments("ye.na.kha.le.ni");
+    const khSegments = segments.filter((s) => s.highlightId === "kh-ch");
+    expect(khSegments.length).toBe(1);
+    expect(khSegments[0].text).toBe("kh");
+  });
+
+  it("correctly identifies 'ch' as kh-ch sound", () => {
+    const segments = splitTransliterationSegments("ech.sar");
+    const chSegments = segments.filter((s) => s.highlightId === "kh-ch");
+    expect(chSegments.length).toBe(1);
+    expect(chSegments[0].text).toBe("ch");
+  });
+
+  it("correctly identifies 'ts' as ts sound", () => {
+    const segments = splitTransliterationSegments("tse.dek");
+    const tsSegments = segments.filter((s) => s.highlightId === "ts");
+    expect(tsSegments.length).toBe(1);
+  });
+
+  it("does not confuse 's' within 'sh'", () => {
+    // "sh" should match the two-char pattern, not "s" + "h"
+    const segments = splitTransliterationSegments("sh");
+    expect(segments).toHaveLength(1);
+    expect(segments[0].highlightId).toBe("sh");
+  });
+
+  it("handles vowels and dots as non-sound characters", () => {
+    const segments = splitTransliterationSegments("a.do.nai");
+    const nonSoundParts = segments.filter((s) => !s.highlightId);
+    // Vowels (a, o, a, i) and dots should have no highlightId
+    expect(nonSoundParts.length).toBeGreaterThan(0);
+  });
+
+  it("handles empty string", () => {
+    const segments = splitTransliterationSegments("");
+    expect(segments).toHaveLength(0);
+  });
+
+  it("handles 'q' as k-q sound", () => {
+    const segments = splitTransliterationSegments("qol");
+    const qSegments = segments.filter((s) => s.highlightId === "k-q");
+    expect(qSegments.length).toBe(1);
+  });
+});
+
+/* ================================================================== */
+/*  4 · splitHebrewClusters                                           */
+/* ================================================================== */
+
+describe("splitHebrewClusters", () => {
+  it("splits simple Hebrew text into letter clusters", () => {
+    const clusters = splitHebrewClusters("אבגד");
+    expect(clusters).toHaveLength(4);
+    expect(clusters.map((c) => c.letterId)).toEqual(["aleph", "bet", "gimel", "dalet"]);
+  });
+
+  it("handles combining marks as part of a cluster", () => {
+    // בּ = bet + dagesh (U+05BC)
+    const clusters = splitHebrewClusters("בּ");
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].letterId).toBe("bet");
+    expect(clusters[0].soundIds).toEqual(["b"]); // dagesh → "b" sound
+  });
+
+  it("bet without dagesh maps to 'v' sound", () => {
+    const clusters = splitHebrewClusters("ב");
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].letterId).toBe("bet");
+    expect(clusters[0].soundIds).toEqual(["v"]);
+  });
+
+  it("kaf with dagesh maps to k-q, without to kh-ch", () => {
+    // כּ (kaf + dagesh) → k-q
+    const withDagesh = splitHebrewClusters("כּ");
+    expect(withDagesh[0].soundIds).toEqual(["k-q"]);
+
+    // כ (kaf without dagesh) → kh-ch
+    const withoutDagesh = splitHebrewClusters("כ");
+    expect(withoutDagesh[0].soundIds).toEqual(["kh-ch"]);
+  });
+
+  it("pe with dagesh maps to p, without to f", () => {
+    // פּ → p
+    const withDagesh = splitHebrewClusters("פּ");
+    expect(withDagesh[0].soundIds).toEqual(["p"]);
+
+    // פ → f
+    const withoutDagesh = splitHebrewClusters("פ");
+    expect(withoutDagesh[0].soundIds).toEqual(["f"]);
+  });
+
+  it("shin dot → 'sh' sound, sin dot → 's' sound", () => {
+    // שׁ = shin (U+05E9 + U+05C1) → "sh"
+    const shin = splitHebrewClusters("שׁ");
+    expect(shin[0].letterId).toBe("shin");
+    expect(shin[0].soundIds).toEqual(["sh"]);
+
+    // שׂ = sin (U+05E9 + U+05C2) → "s"
+    const sin = splitHebrewClusters("שׂ");
+    expect(sin[0].letterId).toBe("sin");
+    expect(sin[0].soundIds).toEqual(["s"]);
+  });
+
+  it("final kaf with/without dagesh maps correctly", () => {
+    // ךּ → k-q
+    const withDagesh = splitHebrewClusters("ךּ");
+    expect(withDagesh[0].letterId).toBe("final-kaf");
+    expect(withDagesh[0].soundIds).toEqual(["k-q"]);
+
+    // ך → kh-ch
+    const withoutDagesh = splitHebrewClusters("ך");
+    expect(withoutDagesh[0].letterId).toBe("final-kaf");
+    expect(withoutDagesh[0].soundIds).toEqual(["kh-ch"]);
+  });
+
+  it("tav with or without dagesh always maps to 't' sound", () => {
+    // תּ → t (dagesh doesn't change pronunciation)
+    const withDagesh = splitHebrewClusters("תּ");
+    expect(withDagesh[0].soundIds).toEqual(["t"]);
+
+    // ת → t
+    const withoutDagesh = splitHebrewClusters("ת");
+    expect(withoutDagesh[0].soundIds).toEqual(["t"]);
+  });
+
+  it("aleph has no sound", () => {
+    const clusters = splitHebrewClusters("א");
+    expect(clusters[0].letterId).toBe("aleph");
+    expect(clusters[0].soundIds).toEqual([]);
+  });
+
+  it("ayin has no sound", () => {
+    const clusters = splitHebrewClusters("ע");
+    expect(clusters[0].letterId).toBe("ayin");
+    expect(clusters[0].soundIds).toEqual([]);
+  });
+
+  it("handles empty string", () => {
+    expect(splitHebrewClusters("")).toHaveLength(0);
+  });
+});
+
+/* ================================================================== */
+/*  5 · Four critical dagesh pairs                                    */
+/* ================================================================== */
+
+describe("Four critical dagesh pairs", () => {
+  it("כ ך (kh) vs כּ ךּ (k) — different sounds based on dagesh", () => {
+    // Without dagesh → kh-ch
+    expect(splitHebrewClusters("כ")[0].soundIds).toEqual(["kh-ch"]);
+    expect(splitHebrewClusters("ך")[0].soundIds).toEqual(["kh-ch"]);
+    // With dagesh → k-q
+    expect(splitHebrewClusters("כּ")[0].soundIds).toEqual(["k-q"]);
+    expect(splitHebrewClusters("ךּ")[0].soundIds).toEqual(["k-q"]);
+  });
+
+  it("בּ (b) vs ב (v) — different sounds based on dagesh", () => {
+    expect(splitHebrewClusters("בּ")[0].soundIds).toEqual(["b"]);
+    expect(splitHebrewClusters("ב")[0].soundIds).toEqual(["v"]);
+  });
+
+  it("פּ (p) vs פ (f) — different sounds based on dagesh", () => {
+    expect(splitHebrewClusters("פּ")[0].soundIds).toEqual(["p"]);
+    expect(splitHebrewClusters("פ")[0].soundIds).toEqual(["f"]);
+  });
+
+  it("שׂ (s) vs שׁ (sh) — different sounds based on sin/shin dot", () => {
+    expect(splitHebrewClusters("שׂ")[0].soundIds).toEqual(["s"]);
+    expect(splitHebrewClusters("שׁ")[0].soundIds).toEqual(["sh"]);
+  });
+
+  it("S sound is represented by ס and שׂ but NOT שׁ", () => {
+    // samekh → "s"
+    expect(splitHebrewClusters("ס")[0].soundIds).toEqual(["s"]);
+    // sin → "s"
+    expect(splitHebrewClusters("שׂ")[0].soundIds).toEqual(["s"]);
+    // shin → "sh" (NOT "s")
+    expect(splitHebrewClusters("שׁ")[0].soundIds).not.toContain("s");
+    expect(splitHebrewClusters("שׁ")[0].soundIds).toEqual(["sh"]);
+  });
+
+  it("dagesh on tav does NOT change pronunciation", () => {
+    // Both with and without dagesh → "t"
+    expect(splitHebrewClusters("ת")[0].soundIds).toEqual(["t"]);
+    expect(splitHebrewClusters("תּ")[0].soundIds).toEqual(["t"]);
+  });
+});
+
+/* ================================================================== */
+/*  6 · Sound-to-letter mapping completeness                          */
+/* ================================================================== */
+
+describe("Sound-to-Hebrew-letter mapping (all 19 sounds)", () => {
+  const cases: Array<{ sound: string; hebrewLetters: string[] }> = [
+    { sound: "s", hebrewLetters: ["ס", "שׂ"] },
+    { sound: "sh", hebrewLetters: ["שׁ"] },
+    { sound: "ts", hebrewLetters: ["צ", "ץ"] },
+    { sound: "z", hebrewLetters: ["ז"] },
+    { sound: "kh-ch", hebrewLetters: ["ח", "כ", "ך"] },
+    { sound: "k-q", hebrewLetters: ["כּ", "ךּ", "ק"] },
+    { sound: "g", hebrewLetters: ["ג"] },
+    { sound: "h", hebrewLetters: ["ה"] },
+    { sound: "d", hebrewLetters: ["ד"] },
+    { sound: "t", hebrewLetters: ["ת", "ט"] },
+    { sound: "n", hebrewLetters: ["נ", "ן"] },
+    { sound: "m", hebrewLetters: ["מ", "ם"] },
+    { sound: "b", hebrewLetters: ["בּ"] },
+    { sound: "v", hebrewLetters: ["ו", "ב"] },
+    { sound: "p", hebrewLetters: ["פּ"] },
+    { sound: "f", hebrewLetters: ["פ"] },
+    { sound: "l", hebrewLetters: ["ל"] },
+    { sound: "r", hebrewLetters: ["ר"] },
+    { sound: "y", hebrewLetters: ["י"] },
+  ];
+
+  for (const { sound, hebrewLetters } of cases) {
+    it(`"${sound}" maps to ${hebrewLetters.join(", ")}`, () => {
+      for (const letter of hebrewLetters) {
+        const clusters = splitHebrewClusters(letter);
+        expect(clusters).toHaveLength(1);
+        expect(clusters[0].soundIds).toContain(sound);
+      }
+    });
+  }
+});
+
+/* ================================================================== */
+/*  7 · countSoundOccurrences / countLetterOccurrences                */
+/* ================================================================== */
+
+describe("countSoundOccurrences", () => {
+  it("counts sounds via transliteration when available", () => {
+    const word = makeWord({ transliteration: "ye.sho.vev" });
+    // "sh" appears once, "v" appears twice (v + v)
+    expect(countSoundOccurrences(word, "sh")).toBe(1);
+    expect(countSoundOccurrences(word, "v")).toBe(2);
+    expect(countSoundOccurrences(word, "y")).toBe(1);
+  });
+
+  it("returns 0 for sounds not present", () => {
+    const word = makeWord({ transliteration: "le.da.vid" });
+    expect(countSoundOccurrences(word, "sh")).toBe(0);
+    expect(countSoundOccurrences(word, "ts")).toBe(0);
+  });
+
+  it("falls back to Hebrew when no transliteration", () => {
+    const word = makeWord({ hebrew: "שׁלום" }); // shin + lamed + vav + mem
+    expect(countSoundOccurrences(word, "sh")).toBe(1);
+    expect(countSoundOccurrences(word, "l")).toBe(1);
+  });
+});
+
+describe("countLetterOccurrences", () => {
+  it("counts letter occurrences in Hebrew text", () => {
+    const word = makeWord({ hebrew: "אבגד" });
+    expect(countLetterOccurrences(word, "aleph")).toBe(1);
+    expect(countLetterOccurrences(word, "bet")).toBe(1);
+    expect(countLetterOccurrences(word, "gimel")).toBe(1);
+    expect(countLetterOccurrences(word, "dalet")).toBe(1);
+  });
+
+  it("returns 0 for letters not present", () => {
+    const word = makeWord({ hebrew: "אבגד" });
+    expect(countLetterOccurrences(word, "shin")).toBe(0);
+    expect(countLetterOccurrences(word, "tav")).toBe(0);
+  });
+
+  it("distinguishes final forms", () => {
+    // ך = final kaf, כ = regular kaf
+    const word = makeWord({ hebrew: "מלך" }); // mem + lamed + final-kaf
+    expect(countLetterOccurrences(word, "final-kaf")).toBe(1);
+    expect(countLetterOccurrences(word, "kaf")).toBe(0);
+  });
+});
+
+/* ================================================================== */
+/*  8 · wordContainsSound / wordContainsLetter                        */
+/* ================================================================== */
+
+describe("wordContainsSound / wordContainsLetter", () => {
+  it("wordContainsSound returns true when sound exists", () => {
+    const word = makeWord({ transliteration: "she.mo" });
+    expect(wordContainsSound(word, "sh")).toBe(true);
+    expect(wordContainsSound(word, "m")).toBe(true);
+  });
+
+  it("wordContainsSound returns false when sound absent", () => {
+    const word = makeWord({ transliteration: "she.mo" });
+    expect(wordContainsSound(word, "ts")).toBe(false);
+  });
+
+  it("wordContainsLetter returns true when letter exists", () => {
+    const word = makeWord({ hebrew: "שׁמו" });
+    expect(wordContainsLetter(word, "shin")).toBe(true);
+  });
+
+  it("wordContainsLetter returns false when letter absent", () => {
+    const word = makeWord({ hebrew: "שׁמו" });
+    expect(wordContainsLetter(word, "aleph")).toBe(false);
+  });
+});
+
+/* ================================================================== */
+/*  9 · buildHighlightedTransliterationSegments                       */
+/* ================================================================== */
+
+describe("buildHighlightedTransliterationSegments", () => {
+  it("highlights only selected sounds", () => {
+    const segments = buildHighlightedTransliterationSegments(
+      "she.mo",
+      new Set(["sh"]),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0].text).toBe("sh");
+    expect(highlighted[0].highlightId).toBe("sh");
+  });
+
+  it("does NOT highlight unselected sounds", () => {
+    const segments = buildHighlightedTransliterationSegments(
+      "she.mo",
+      new Set(["ts"]), // "ts" is not in "she.mo"
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted).toHaveLength(0);
+  });
+
+  it("highlights multiple selected sounds", () => {
+    const segments = buildHighlightedTransliterationSegments(
+      "ye.sho.vev",
+      new Set(["sh", "v"]),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("with empty selection, highlights nothing", () => {
+    const segments = buildHighlightedTransliterationSegments(
+      "le.da.vid",
+      new Set(),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted).toHaveLength(0);
+  });
+});
+
+/* ================================================================== */
+/*  10 · buildHighlightedHebrewSegments                               */
+/* ================================================================== */
+
+describe("buildHighlightedHebrewSegments", () => {
+  it("highlights Hebrew letters by selected sound", () => {
+    // שׁלום — shin maps to "sh" sound
+    const segments = buildHighlightedHebrewSegments(
+      "שׁלום",
+      new Set(["sh"]),
+      new Set(),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted.length).toBeGreaterThan(0);
+    expect(highlighted[0].highlightId).toBe("sh");
+  });
+
+  it("highlights Hebrew letters by selected letter ID", () => {
+    const segments = buildHighlightedHebrewSegments(
+      "אבגד",
+      new Set(),
+      new Set(["aleph"]),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0].highlightId).toBe("aleph");
+  });
+
+  it("sound selection takes priority over letter selection", () => {
+    // ב without dagesh → "v" sound, letterId = "bet"
+    const segments = buildHighlightedHebrewSegments(
+      "ב",
+      new Set(["v"]),
+      new Set(["bet"]),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0].highlightId).toBe("v"); // sound takes priority
+  });
+
+  it("with no selections, highlights nothing", () => {
+    const segments = buildHighlightedHebrewSegments(
+      "אבגד",
+      new Set(),
+      new Set(),
+    );
+    const highlighted = segments.filter((s) => s.highlightId);
+    expect(highlighted).toHaveLength(0);
+  });
+
+  it("highlights individual letters, not whole words", () => {
+    // Select only "aleph" — only first letter highlighted
+    const segments = buildHighlightedHebrewSegments(
+      "אבגד",
+      new Set(),
+      new Set(["aleph"]),
+    );
+    expect(segments.length).toBeGreaterThanOrEqual(2);
+    expect(segments[0].highlightId).toBe("aleph");
+    expect(segments[1].highlightId).toBeUndefined();
+  });
+});
+
+/* ================================================================== */
+/*  11 · LETTER_CHIP_GROUPS (grouped display for PDF spec)            */
+/* ================================================================== */
+
+describe("LETTER_CHIP_GROUPS", () => {
+  it("contains exactly 22 groups (matching PDF spec)", () => {
+    expect(LETTER_CHIP_GROUPS).toHaveLength(22);
+  });
+
+  it("groups final forms together: כ ך, מ ם, נ ן, צ ץ, שׂ שׁ", () => {
+    const kafGroup = LETTER_CHIP_GROUPS.find((g) => g.label === "כ ך");
+    expect(kafGroup).toBeDefined();
+    expect(kafGroup!.memberIds).toEqual(["kaf", "final-kaf"]);
+
+    const memGroup = LETTER_CHIP_GROUPS.find((g) => g.label === "מ ם");
+    expect(memGroup).toBeDefined();
+    expect(memGroup!.memberIds).toEqual(["mem", "final-mem"]);
+
+    const nunGroup = LETTER_CHIP_GROUPS.find((g) => g.label === "נ ן");
+    expect(nunGroup).toBeDefined();
+    expect(nunGroup!.memberIds).toEqual(["nun", "final-nun"]);
+
+    const tsadiGroup = LETTER_CHIP_GROUPS.find((g) => g.label === "צ ץ");
+    expect(tsadiGroup).toBeDefined();
+    expect(tsadiGroup!.memberIds).toEqual(["tsadi", "final-tsadi"]);
+
+    const shinSinGroup = LETTER_CHIP_GROUPS.find((g) => g.label === "שׂ שׁ");
+    expect(shinSinGroup).toBeDefined();
+    expect(shinSinGroup!.memberIds).toEqual(["sin", "shin"]);
+  });
+
+  it("every group memberIds maps to a valid LETTER_CHIP", () => {
+    for (const group of LETTER_CHIP_GROUPS) {
+      for (const memberId of group.memberIds) {
+        expect(LETTER_CHIP_MAP.get(memberId)).toBeDefined();
+      }
+    }
+  });
+
+  it("every individual LETTER_CHIP belongs to exactly one group", () => {
+    const allMemberIds = LETTER_CHIP_GROUPS.flatMap((g) => g.memberIds);
+    // Every LETTER_CHIP id is present
+    for (const chip of LETTER_CHIPS) {
+      expect(allMemberIds).toContain(chip.id);
+    }
+    // No duplicates
+    expect(new Set(allMemberIds).size).toBe(allMemberIds.length);
+  });
+
+  it("standalone letters have single-element memberIds", () => {
+    const aleph = LETTER_CHIP_GROUPS.find((g) => g.id === "aleph");
+    expect(aleph).toBeDefined();
+    expect(aleph!.memberIds).toEqual(["aleph"]);
+
+    const lamed = LETTER_CHIP_GROUPS.find((g) => g.id === "lamed");
+    expect(lamed).toBeDefined();
+    expect(lamed!.memberIds).toEqual(["lamed"]);
+  });
+
+  it("each group has a valid palette", () => {
+    for (const group of LETTER_CHIP_GROUPS) {
+      expect(group.palette.fill).toBeDefined();
+      expect(group.palette.border).toBeDefined();
+      expect(group.palette.text).toBeDefined();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    include: ["tests/unit/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- add transliteration as a non-English display mode alongside the existing English/parallel/Hebrew layout switcher
- implement the Sounds pane with Hebrew Sound Distribution and Hebrew Letter Distribution chip sets, local smart-highlight state, and inline per-letter highlighting in transliteration and Hebrew views
- add Playwright coverage for the public study view and fix local tooling needed to build and test this flow (`dotenv`, Playwright config, ignored artifacts, removal of the dead `@xata.io/cli` dependency)

## What changed
- added a non-English display dropdown so the public and edit study views can switch between `Hebrew OHB` and `Transliteration`
- enabled the `Sounds` tab and replaced the placeholder pane with the requested sound and letter distribution UIs
- implemented selected-chip-only highlighting logic so smart highlight only applies after choosing chips, not to the entire distribution by default
- rendered inline highlight spans inside the passage instead of coloring whole word boxes, including matching Hebrew letters when sound chips are active
- kept the distribution highlighting browser-local rather than persisting individual-letter highlight state to study metadata/database
- exposed the language/display controls in view mode so the new sound tools can be used on public studies
- added Playwright tests for transliteration sound highlighting and Hebrew letter highlighting on a public study route

## Validation
- `npm run build`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3001 npm run test:e2e` against the production build served with `PORT=3001 npm run start`
- manual Playwright verification on `http://localhost:3000/study/d6ef7cl250emugaodqi0/view` for:
  - switching from English to parallel mode
  - switching the non-English pane between Hebrew OHB and transliteration
  - applying sound-distribution smart highlight in transliteration view
  - applying Hebrew-letter-distribution smart highlight in Hebrew view

## Notes
- I created a local-only `.env.local` for testing; it is covered by the existing `.env*` gitignore rule and is not part of this PR.
- I was able to validate the Clerk sign-in page renders locally, but I could not complete a real Google OAuth login flow from this environment because the current Clerk configuration does not expose a visible Google sign-in button in the rendered sign-in UI.
- Vercel CLI on this machine is authenticated, but I do not see an existing local Vercel project linkage for `sela-webapp`; I’m relying on the repository PR/integration checks for preview/build status here.
