### PR TITLE
Add anonymous Psalm 1 trial flow with Clerk handoff

### DIFF
--- a/src/app/api/noteSync/route.ts
+++ b/src/app/api/noteSync/route.ts
@@ -1,27 +1,30 @@
 import { fetchStudyById, updateStudyNotes } from "@/lib/actions";
+import { getAnonymousOwnerSessionId, ANONYMOUS_SESSION_COOKIE } from "@/lib/anonymous";
 import { getAuth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(req: NextRequest) {
   const { userId } = getAuth(req);
-  const content: {studyId:string, text: string} = await req.json();
-  if (!userId) return NextResponse.json({error: 'Unauthorized'}, {status: 401});
-  try{
+  const content: { studyId: string; text: string } = await req.json();
+
+  try {
     const study = await fetchStudyById(content.studyId);
-    if (!study) return NextResponse.json({error: 'No study found'}, {status: 404});
-    if (study.owner !== userId) return NextResponse.json({error: 'Unauthorized'}, {status: 401});
-    if (study.owner == userId ) {
-      if (!study.notes) {
-        updateStudyNotes(study.id, content.text);
-        return NextResponse.json({ message: "Saved" }, { status: 200 });
-      }
-      const parsedNotes = JSON.parse(study.notes);
-      const parsedRequestNotes = JSON.parse(content.text);
-      console.log(parsedRequestNotes);
-      updateStudyNotes(study.id, JSON.stringify(parsedRequestNotes))
-      return NextResponse.json({ message: "Saved" }, { status: 200 });
-  }
+    if (!study) return NextResponse.json({ error: "No study found" }, { status: 404 });
+
+    const anonymousSessionId = req.cookies.get(ANONYMOUS_SESSION_COOKIE)?.value;
+    const ownerAnonymousSessionId = getAnonymousOwnerSessionId(study.owner);
+
+    const isAuthorized =
+      study.owner === userId ||
+      Boolean(ownerAnonymousSessionId && anonymousSessionId && ownerAnonymousSessionId === anonymousSessionId);
+
+    if (!isAuthorized) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    updateStudyNotes(study.id, content.text);
+    return NextResponse.json({ message: "Saved" }, { status: 200 });
   } catch (error) {
-    return NextResponse.json({ message: "Database Error"}, { status: 404})
+    return NextResponse.json({ message: "Database Error" }, { status: 404 });
   }
-};
+}

--- a/src/app/auth/complete/page.tsx
+++ b/src/app/auth/complete/page.tsx
@@ -1,0 +1,32 @@
+import { cookies } from "next/headers";
+import { currentUser } from "@clerk/nextjs";
+import { redirect } from "next/navigation";
+
+import { claimAnonymousStudy } from "@/lib/actions";
+import { ANONYMOUS_SESSION_COOKIE } from "@/lib/anonymous";
+
+export default async function AuthCompletePage({
+  searchParams,
+}: {
+  searchParams?: { studyId?: string };
+}) {
+  const user = await currentUser();
+
+  if (!user) {
+    return redirect("/");
+  }
+
+  const studyId = searchParams?.studyId;
+  const anonymousSessionId = cookies().get(ANONYMOUS_SESSION_COOKIE)?.value;
+
+  if (studyId && anonymousSessionId) {
+    const normalizedStudyId = studyId.startsWith("rec_") ? studyId : `rec_${studyId}`;
+    const claimedStudyId = await claimAnonymousStudy(normalizedStudyId, anonymousSessionId);
+
+    if (claimedStudyId) {
+      return redirect(`/study/${claimedStudyId.replace(/^rec_/, "")}/edit`);
+    }
+  }
+
+  return redirect("/dashboard/home");
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,50 @@
-import { redirect } from "next/navigation"
+import Link from "next/link";
+import { currentUser } from "@clerk/nextjs";
 
-export default function Home() {
-  return redirect("/dashboard/home");
+export default async function Home() {
+  const user = await currentUser();
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-6 py-16">
+      <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
+        <h1 className="text-4xl font-bold text-slate-900">Sela Bible Poetry</h1>
+        <p className="text-lg text-slate-700">
+          Start analyzing Psalm 1 instantly with Notes, Motif, and Syntax tools — no login required.
+        </p>
+
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          <Link
+            href="/try/psalm-1"
+            className="rounded-md bg-primary px-6 py-3 font-semibold text-black shadow hover:opacity-90"
+          >
+            Try Psalm 1
+          </Link>
+
+          {user ? (
+            <Link
+              href="/dashboard/home"
+              className="rounded-md border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-800 hover:bg-slate-100"
+            >
+              Go to My Studies
+            </Link>
+          ) : (
+            <>
+              <Link
+                href="/sign-in"
+                className="rounded-md border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-800 hover:bg-slate-100"
+              >
+                Log in
+              </Link>
+              <Link
+                href="/sign-up"
+                className="rounded-md border border-slate-300 bg-white px-6 py-3 font-semibold text-slate-800 hover:bg-slate-100"
+              >
+                Create account
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/app/study/[id]/edit/page.tsx
+++ b/src/app/study/[id]/edit/page.tsx
@@ -1,7 +1,9 @@
 import { notFound, redirect } from 'next/navigation';
 import { currentUser } from '@clerk/nextjs';
+import { cookies } from 'next/headers';
 
 import { fetchStudyById, fetchPassageData } from '@/lib/actions';
+import { getAnonymousOwnerSessionId, ANONYMOUS_SESSION_COOKIE } from '@/lib/anonymous';
 import StudyPane from "@/components/StudyPane";
 
 export async function generateMetadata({ params }: { params: { id: string } }) {
@@ -27,11 +29,20 @@ export default async function StudyPage({ params }: { params: { id: string } }) 
     fetchPassageData(studyId)
   ]);
 
+  const anonymousSessionId = cookies().get(ANONYMOUS_SESSION_COOKIE)?.value;
+  const studyAnonymousSessionId = getAnonymousOwnerSessionId(result.study?.owner);
+  const isAnonymousOwner = Boolean(
+    !thisUser &&
+      anonymousSessionId &&
+      studyAnonymousSessionId &&
+      anonymousSessionId === studyAnonymousSessionId,
+  );
+
   /*
     Authorization check
-    Only the owner has write access to this study. Users will be redirected to the view page if the study is public. 
+    Only the owner has write access to this study.
   */
-  if (!result.study || (thisUser?.id != result.study.owner && !result.study.public)) {
+  if (!result.study || (thisUser?.id != result.study.owner && !isAnonymousOwner)) {
     notFound();
     return redirect(`/study/${params.id}/view`);
   }

--- a/src/app/try/psalm-1/route.ts
+++ b/src/app/try/psalm-1/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { ensureAnonymousPsalmStudy } from "@/lib/actions";
+import { ANONYMOUS_SESSION_COOKIE } from "@/lib/anonymous";
+
+const createSessionId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+export async function GET(request: NextRequest) {
+  let anonymousSessionId = request.cookies.get(ANONYMOUS_SESSION_COOKIE)?.value;
+
+  if (!anonymousSessionId) {
+    anonymousSessionId = createSessionId();
+  }
+
+  const studyId = await ensureAnonymousPsalmStudy(anonymousSessionId);
+  const response = NextResponse.redirect(new URL(`/study/${studyId.replace(/^rec_/, "")}/edit`, request.url));
+
+  response.cookies.set(ANONYMOUS_SESSION_COOKIE, anonymousSessionId, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 60 * 60 * 24 * 7,
+    path: "/",
+  });
+
+  return response;
+}

--- a/src/components/StudyPane/Header/DropdownUser.tsx
+++ b/src/components/StudyPane/Header/DropdownUser.tsx
@@ -1,41 +1,44 @@
-import { useEffect, useRef, useState } from "react";
-import { UserButton } from '@clerk/nextjs';
+import {
+  SignedIn,
+  SignedOut,
+  SignInButton,
+  SignUpButton,
+  UserButton,
+} from "@clerk/nextjs";
 
-const DropdownUser = () => {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
+import { isAnonymousOwner } from "@/lib/anonymous";
 
-  const trigger = useRef<any>(null);
-  const dropdown = useRef<any>(null);
+type DropdownUserProps = {
+  studyId: string;
+  owner: string;
+};
 
-  // close on click outside
-  useEffect(() => {
-    const clickHandler = ({ target }: MouseEvent) => {
-      if (!dropdown.current) return;
-      if (
-        !dropdownOpen ||
-        dropdown.current.contains(target) ||
-        trigger.current.contains(target)
-      )
-        return;
-      setDropdownOpen(false);
-    };
-    document.addEventListener("click", clickHandler);
-    return () => document.removeEventListener("click", clickHandler);
-  });
-
-  // close if the esc key is pressed
-  useEffect(() => {
-    const keyHandler = ({ keyCode }: KeyboardEvent) => {
-      if (!dropdownOpen || keyCode !== 27) return;
-      setDropdownOpen(false);
-    };
-    document.addEventListener("keydown", keyHandler);
-    return () => document.removeEventListener("keydown", keyHandler);
-  });
+const DropdownUser = ({ studyId, owner }: DropdownUserProps) => {
+  const isTrialStudy = isAnonymousOwner(owner);
+  const studyIdParam = studyId.replace(/^rec_/, "");
+  const redirectUrl = `/auth/complete?studyId=${studyIdParam}`;
 
   return (
-    <div className="relative">
+    <div className="relative flex items-center gap-2">
+      <SignedOut>
+        {isTrialStudy && (
+          <>
+            <SignInButton mode="modal" forceRedirectUrl={redirectUrl}>
+              <button className="rounded border border-slate-300 bg-white px-3 py-1 text-sm font-medium text-slate-700 hover:bg-slate-100">
+                Log in
+              </button>
+            </SignInButton>
+            <SignUpButton mode="modal" forceRedirectUrl={redirectUrl}>
+              <button className="rounded bg-primary px-3 py-1 text-sm font-semibold text-black hover:opacity-90">
+                Create account
+              </button>
+            </SignUpButton>
+          </>
+        )}
+      </SignedOut>
+      <SignedIn>
         <UserButton afterSignOutUrl="/" />
+      </SignedIn>
     </div>
   );
 };

--- a/src/components/StudyPane/Header/index.tsx
+++ b/src/components/StudyPane/Header/index.tsx
@@ -71,7 +71,7 @@ const Header = ({
               {/* <!-- Dark Mode Toggler --> */}
 
               {/* <!-- User Area --> */}
-              {<DropdownUser />}
+              {<DropdownUser studyId={study.id} owner={study.owner} />}
               {/* <!-- User Area --> */}
           </div>
         </div>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
 import { currentUser, clerkClient } from '@clerk/nextjs';
 
 import { db } from '../db';
@@ -10,6 +11,7 @@ import { and, or, ilike, like, eq, asc, desc, count, gte, lte, gt, lt, SQL } fro
 import { nanoid } from 'nanoid';
 
 import { parsePassageInfo, PassageInfo } from './utils';
+import { makeAnonymousOwner, getAnonymousOwnerSessionId, ANONYMOUS_SESSION_COOKIE } from './anonymous';
 import { StudyData, PassageData, PassageStaticData, StudyMetadata, WordProps, FetchStudiesResult } from './data';
 
 const SORT_COLUMNS = {
@@ -39,6 +41,37 @@ const formatStrongNumberForDisplay = (value: string) => {
 };
 
 
+
+
+async function canEditStudy(studyId: string) {
+  const [studyRow, user] = await Promise.all([
+    db
+      .select({ owner: study.owner })
+      .from(study)
+      .where(eq(study.id, studyId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null),
+    currentUser(),
+  ]);
+
+  if (!studyRow) {
+    return false;
+  }
+
+  if (user?.id && studyRow.owner === user.id) {
+    return true;
+  }
+
+  const anonymousSessionId = cookies().get(ANONYMOUS_SESSION_COOKIE)?.value;
+  const ownerAnonymousSessionId = getAnonymousOwnerSessionId(studyRow.owner);
+
+  return Boolean(
+    !user &&
+      anonymousSessionId &&
+      ownerAnonymousSessionId &&
+      anonymousSessionId === ownerAnonymousSessionId,
+  );
+}
 export async function fetchStudyById(studyId: string) {
   try {
     const row = await db
@@ -120,6 +153,10 @@ export async function updateMetadataInDb(studyId: string, studyMetadata: StudyMe
   "use server";
 
   try {
+    const canEdit = await canEditStudy(studyId);
+    if (!canEdit) {
+      return { message: 'Unauthorized' };
+    }
     const metadataJson = JSON.stringify(studyMetadata);
     if (metadataJson)
     {
@@ -146,6 +183,66 @@ export async function deleteStudy(studyId: string) {
   } catch (error) {
     return { message: 'Database Error: Failed to delete study.' };
   }
+}
+
+
+export async function ensureAnonymousPsalmStudy(sessionId: string) {
+  const anonymousOwner = makeAnonymousOwner(sessionId);
+
+  const existingStudy = await db
+    .select({ id: study.id })
+    .from(study)
+    .where(
+      and(
+        eq(study.owner, anonymousOwner),
+        eq(study.book, 'psalms'),
+        eq(study.passage, '1')
+      )
+    )
+    .orderBy(desc(study.updatedAt))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  if (existingStudy?.id) {
+    return existingStudy.id;
+  }
+
+  const [record] = await db
+    .insert(study)
+    .values({
+      id: "rec_" + nanoid(20),
+      name: "Psalm 1 Trial Study",
+      passage: '1',
+      book: 'psalms',
+      owner: anonymousOwner,
+      metadata: { words: {} },
+      public: false,
+      model: false,
+      starred: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    .returning({ id: study.id });
+
+  return record.id;
+}
+
+export async function claimAnonymousStudy(studyId: string, anonymousSessionId: string) {
+  const user = await currentUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const anonymousOwner = makeAnonymousOwner(anonymousSessionId);
+
+  const [claimedStudy] = await db
+    .update(study)
+    .set({ owner: user.id, updatedAt: new Date().toISOString() })
+    .where(and(eq(study.id, studyId), eq(study.owner, anonymousOwner)))
+    .returning({ id: study.id });
+
+  return claimedStudy?.id ?? null;
 }
 
 export async function createStudy(passage: string, book: string) {

--- a/src/lib/anonymous.ts
+++ b/src/lib/anonymous.ts
@@ -1,0 +1,12 @@
+export const ANONYMOUS_OWNER_PREFIX = "anon:";
+export const ANONYMOUS_SESSION_COOKIE = "sela_anon_session";
+
+export const makeAnonymousOwner = (sessionId: string) => `${ANONYMOUS_OWNER_PREFIX}${sessionId}`;
+
+export const isAnonymousOwner = (owner: string | null | undefined) =>
+  Boolean(owner && owner.startsWith(ANONYMOUS_OWNER_PREFIX));
+
+export const getAnonymousOwnerSessionId = (owner: string | null | undefined) =>
+  owner && owner.startsWith(ANONYMOUS_OWNER_PREFIX)
+    ? owner.slice(ANONYMOUS_OWNER_PREFIX.length)
+    : null;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,8 +4,15 @@ import { authMiddleware } from "@clerk/nextjs";
 // Please edit this to allow other routes to be public as needed.
 // See https://clerk.com/docs/references/nextjs/auth-middleware for more information about configuring your Middleware
 export default authMiddleware({
-  // publicRoutes: ["/study/(.*)/view", "/api/admin/migrate"]
-  publicRoutes: ["/study/(.*)/view"]
+  publicRoutes: [
+    "/",
+    "/try/(.*)",
+    "/study/(.*)/view",
+    "/study/(.*)/edit",
+    "/auth/complete",
+    "/sign-in(.*)",
+    "/sign-up(.*)",
+  ]
 });
  
 export const config = {


### PR DESCRIPTION
### Motivation
- Provide a “try before login” experience so visitors can start analyzing Psalm 1 immediately without being forced to sign in.
- Persist anonymous session state temporarily and allow full use of in-study analysis tools (notes, motif, syntax) during the trial.
- Enable seamless handoff so when a visitor signs in or signs up via Clerk their anonymous trial work is claimed and associated with their account.

### Description
- Exposed the landing page and trial routes in Clerk middleware by making `/`, `/try/(.*)`, `/auth/complete`, and several sign routes public and allowing the edit route to remain reachable while enforcing page-level ownership checks in `src/middleware.ts` and `src/app/page.tsx`.
- Added anonymous ownership helpers in `src/lib/anonymous.ts` and introduced server helpers in `src/lib/actions.ts`: `ensureAnonymousPsalmStudy(sessionId)` to create/reuse an anonymous Psalm 1 study, `claimAnonymousStudy(studyId, anonymousSessionId)` to transfer ownership to a Clerk user, and `canEditStudy(studyId)` to gate metadata writes to authenticated owners or matching anonymous cookie owners.
- Implemented a cookie-backed trial bootstrap route at `GET /try/psalm-1` (`src/app/try/psalm-1/route.ts`) which provisions or reuses a Psalm 1 study and redirects into the editor while setting a persistent anonymous session cookie; added an auth-complete route (`src/app/auth/complete/page.tsx`) that claims the anonymous study after sign-in and redirects to the continuing study.
- Updated study edit authorization (`src/app/study/[id]/edit/page.tsx`), notes-saving API (`src/app/api/noteSync/route.ts`), and metadata persistence (`updateMetadataInDb`) to permit edits/saves by either the authenticated owner or the anonymous cookie owner, and updated the study header UI (`src/components/StudyPane/Header/DropdownUser.tsx` and `Header/index.tsx`) to present Clerk sign-in/sign-up actions that redirect into the claim flow for trial users.

### Testing
- Ran `npm run lint` in this environment and it failed because `next` is not installed (`sh: 1: next: not found`), so lint/type checks could not be completed here.
- No other automated tests were executed in this environment (no unit/integration test framework was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9e41bab188325b7a055975ff27a82)