### PR TITLE
Collapse notes bugs

### DIFF
--- a/src/components/StudyPane/InfoPane/Layers.collapse.test.tsx
+++ b/src/components/StudyPane/InfoPane/Layers.collapse.test.tsx
@@ -125,6 +125,18 @@ describe("Layers expanded-note collapse", () => {
     expect(isExpanded()).toBe(true);
   });
 
+  it("collapses when the collapse button in the note margin is clicked", () => {
+    renderLayers();
+    // The button only exists once the note is expanded.
+    expect(screen.queryByLabelText("Collapse note")).toBeNull();
+    expandNote();
+
+    fireEvent.click(screen.getByLabelText("Collapse note"));
+
+    expect(isExpanded()).toBe(false);
+    expect(screen.getByText(NOTE_PEEK)).toBeInTheDocument();
+  });
+
   it("still collapses when clicking the layer header inside the sidebar", () => {
     renderLayers();
     expandNote();

--- a/src/components/StudyPane/InfoPane/Layers.collapse.test.tsx
+++ b/src/components/StudyPane/InfoPane/Layers.collapse.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Regression tests for the expanded layer-note collapse behaviour.
+ *
+ * The expanded note used to collapse on ANY mousedown outside the note wrapper,
+ * which meant:
+ *   - clicking a colour control (highlight / text colour) in the toolbar or the
+ *     note's floating format menu closed the note (bug 1), and
+ *   - clicking passage content (strophes / words / stanzas) closed it (bug 2).
+ *
+ * The note must now stay open for clicks anywhere OUTSIDE the layers sidebar
+ * (passage, toolbar, portaled format menu) and only collapse when the user
+ * clicks elsewhere inside the sidebar (e.g. the layer header).
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { DEFAULT_LAYER_FILL, DEFAULT_LAYER_BORDER, DEFAULT_LAYER_TEXT } from "@/lib/colors";
+
+// Mock the heavy StudyPane index so importing FormatContext is cheap.
+vi.mock("..", async () => {
+  const ReactMod = await import("react");
+  return { FormatContext: ReactMod.createContext({} as any) };
+});
+
+// The confirmation modal pulls in unrelated deps; render nothing.
+vi.mock("@/components/Modals/DeleteLayer", () => ({ default: () => null }));
+
+// Stub the Tiptap editor: we only need a recognisable marker for "expanded".
+vi.mock("./RichTextEditor", () => ({
+  default: () => <div data-testid="rich-editor">note editor</div>,
+}));
+
+import Layers from "./Layers";
+import { FormatContext } from "..";
+
+const LAYER = { id: 0, name: "Default", fill: DEFAULT_LAYER_FILL, border: DEFAULT_LAYER_BORDER, text: DEFAULT_LAYER_TEXT };
+const NOTE_PEEK = "My layer note";
+
+function renderLayers() {
+  const ctx: any = {
+    ctxColorAction: 0,
+    ctxSelectedColor: "",
+    ctxSetColorAction: vi.fn(),
+    ctxSetSelectedColor: vi.fn(),
+    ctxSetColorFill: vi.fn(),
+    ctxSetBorderColor: vi.fn(),
+    ctxSetTextColor: vi.fn(),
+    ctxNumSelectedLayers: 0,
+    ctxSetNumSelectedLayers: vi.fn(),
+    ctxNumSelectedWords: 0,
+    ctxSetSelectedWords: vi.fn(),
+    ctxSetNumSelectedWords: vi.fn(),
+    ctxNumSelectedStrophes: 0,
+    ctxSetSelectedStrophes: vi.fn(),
+    ctxSetNumSelectedStrophes: vi.fn(),
+    ctxStudyId: "study-1",
+    ctxStudyNotes: JSON.stringify({ layerNotes: { "0": NOTE_PEEK } }),
+    ctxSetStudyNotes: vi.fn(),
+    ctxLayers: [LAYER],
+    ctxSetLayers: vi.fn(),
+    ctxActiveLayerId: 0,
+    ctxSwitchLayer: vi.fn(),
+    ctxCreateLayer: vi.fn(),
+    ctxDeleteLayer: vi.fn(),
+    ctxInViewMode: false,
+  };
+
+  return render(
+    <FormatContext.Provider value={ctx}>
+      <Layers />
+    </FormatContext.Provider>,
+  );
+}
+
+/** Expand the note by clicking its one-line peek. */
+function expandNote() {
+  fireEvent.click(screen.getByText(NOTE_PEEK));
+  expect(screen.getByTestId("rich-editor")).toBeInTheDocument();
+}
+
+const isExpanded = () => screen.queryByTestId("rich-editor") !== null;
+
+describe("Layers expanded-note collapse", () => {
+  let outside: HTMLElement;
+
+  beforeEach(() => {
+    outside = document.createElement("div");
+    document.body.appendChild(outside);
+  });
+
+  it("stays open when clicking a colour control outside the sidebar (bug 1: toolbar)", () => {
+    renderLayers();
+    expandNote();
+
+    // A toolbar colour swatch lives above the panes — outside the sidebar.
+    fireEvent.mouseDown(outside);
+
+    expect(isExpanded()).toBe(true);
+  });
+
+  it("stays open when clicking the note's floating colour menu (bug 1: role=menu)", () => {
+    renderLayers();
+    expandNote();
+
+    // The rich-text format menu is portaled to <body> with role="menu".
+    const menu = document.createElement("div");
+    menu.setAttribute("role", "menu");
+    const swatch = document.createElement("button");
+    menu.appendChild(swatch);
+    document.body.appendChild(menu);
+
+    fireEvent.mouseDown(swatch);
+
+    expect(isExpanded()).toBe(true);
+  });
+
+  it("stays open when clicking passage content — strophes / words / stanzas (bug 2)", () => {
+    renderLayers();
+    expandNote();
+
+    // The passage pane is a sibling of the sidebar, outside it.
+    fireEvent.mouseDown(outside);
+
+    expect(isExpanded()).toBe(true);
+  });
+
+  it("still collapses when clicking the layer header inside the sidebar", () => {
+    renderLayers();
+    expandNote();
+
+    // The layer name sits in the header row, inside the sidebar but outside the note.
+    fireEvent.mouseDown(screen.getByText("Default"));
+
+    expect(isExpanded()).toBe(false);
+    expect(screen.getByText(NOTE_PEEK)).toBeInTheDocument();
+  });
+});

--- a/src/components/StudyPane/InfoPane/Layers.tsx
+++ b/src/components/StudyPane/InfoPane/Layers.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { LuTextSelect } from "react-icons/lu";
+import { BiCollapseVertical } from "react-icons/bi";
 import { IconTrash } from "@tabler/icons-react";
 import { FormatContext } from "..";
 import { ColorActionType } from "@/lib/types";
@@ -506,12 +507,12 @@ const Layers = () => {
 
               {/* Note lives inside the box — only for the active layer. Click the
                   peek to expand into a full-height editor; collapse by clicking
-                  outside the note. */}
+                  outside the note or the collapse button in the right margin. */}
               {isSelected && (
                 notesExpanded ? (
                   <div
                     ref={expandedNoteRef}
-                    className="flex min-h-0 flex-1 flex-col px-3 pb-3"
+                    className="relative flex min-h-0 flex-1 flex-col px-3 pb-3"
                   >
                     <RichTextEditor
                       value={noteDoc}
@@ -522,6 +523,17 @@ const Layers = () => {
                       fill
                       className="min-h-0 flex-1 cursor-text bg-white dark:bg-boxdark"
                     />
+                    {/* Circular collapse button floating over the note box's
+                        top-right corner. */}
+                    <button
+                      type="button"
+                      title="Collapse note"
+                      aria-label="Collapse note"
+                      onClick={() => setNotesExpanded(false)}
+                      className="absolute right-2 top-1 z-20 flex h-6 w-6 items-center justify-center rounded-full border border-stroke bg-white text-black/60 shadow-sm transition hover:text-black dark:border-strokedark dark:bg-boxdark dark:text-white/70"
+                    >
+                      <BiCollapseVertical size={14} style={{ pointerEvents: "none" }} />
+                    </button>
                   </div>
                 ) : (
                   <div className="px-3 pb-3">

--- a/src/components/StudyPane/InfoPane/Layers.tsx
+++ b/src/components/StudyPane/InfoPane/Layers.tsx
@@ -134,18 +134,27 @@ const Layers = () => {
     setNotesExpanded(false);
   }, [ctxActiveLayerId]);
 
-  // Collapse the expanded note when the user clicks anywhere outside it.
-  // A document-level listener (instead of textarea onBlur) avoids the event
-  // race that made an in-note collapse button unreliable.
+  // Collapse the expanded note when the user clicks elsewhere INSIDE the layers
+  // sidebar (e.g. the layer header). A document-level listener (instead of
+  // textarea onBlur) avoids the event race that made an in-note collapse button
+  // unreliable. Crucially, clicks OUTSIDE the sidebar must NOT collapse the note:
+  // the user needs to reach the toolbar colour controls and click passage
+  // strophes / words / stanzas (to highlight and reference them) while writing.
+  const paneRef = useRef<HTMLDivElement | null>(null);
   const expandedNoteRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (!notesExpanded) return;
     const onDocMouseDown = (e: MouseEvent) => {
       const target = e.target as Node;
+      // Clicks inside the note keep it open.
       if (expandedNoteRef.current?.contains(target)) return;
-      // The rich-text formatting menu is portaled to document.body, so clicks on
-      // it land outside the note wrapper — don't treat those as an outside click.
+      // The rich-text formatting menu (highlight / text-colour pickers) is
+      // portaled to document.body, so its clicks land outside the note wrapper —
+      // don't treat those as an outside click.
       if (target instanceof Element && target.closest('[role="menu"]')) return;
+      // Clicks outside the sidebar (passage, toolbar, other panes) leave the note
+      // open; only a click elsewhere within the sidebar collapses it.
+      if (!paneRef.current?.contains(target)) return;
       setNotesExpanded(false);
     };
     document.addEventListener("mousedown", onDocMouseDown);
@@ -376,7 +385,7 @@ const Layers = () => {
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div ref={paneRef} className="flex h-full flex-col">
 
       <div className="flex min-h-0 flex-1 flex-col gap-4 mt-8 p-6.5">
         {ctxLayers.map((layer) => {

--- a/src/components/StudyPane/InfoPane/RichTextEditor.test.tsx
+++ b/src/components/StudyPane/InfoPane/RichTextEditor.test.tsx
@@ -47,6 +47,30 @@ describe("RichTextEditor", () => {
     expect(screen.getByText("Hello notes")).toBeInTheDocument();
   });
 
+  it("lays the highlight palette out in two even rows (5 + 5)", async () => {
+    render(<RichTextEditor value={sampleDoc} onChange={() => {}} editable />);
+    fireEvent.click(await screen.findByLabelText("Formatting options"));
+
+    // Open the highlight swatch dropdown (ToolbarButton fires on mousedown).
+    fireEvent.mouseDown(await screen.findByLabelText("Highlight"));
+
+    // 10 highlight colours arranged in 5 columns → two balanced rows.
+    const grid = (await screen.findByTitle("#FFF176")).parentElement as HTMLElement;
+    expect(grid.querySelectorAll("button")).toHaveLength(10);
+    expect(grid.style.gridTemplateColumns).toBe("repeat(5, 1.25rem)");
+  });
+
+  it("keeps the 12-colour text palette in two even rows (6 + 6)", async () => {
+    render(<RichTextEditor value={sampleDoc} onChange={() => {}} editable />);
+    fireEvent.click(await screen.findByLabelText("Formatting options"));
+
+    fireEvent.mouseDown(await screen.findByLabelText("Text color"));
+
+    const grid = (await screen.findByTitle("#000000")).parentElement as HTMLElement;
+    expect(grid.querySelectorAll("button")).toHaveLength(12);
+    expect(grid.style.gridTemplateColumns).toBe("repeat(6, 1.25rem)");
+  });
+
   it("opens the formatting menu on right-click inside the editor", async () => {
     render(<RichTextEditor value={sampleDoc} onChange={() => {}} editable />);
     await screen.findByText("Hello notes");

--- a/src/components/StudyPane/InfoPane/RichTextEditor.tsx
+++ b/src/components/StudyPane/InfoPane/RichTextEditor.tsx
@@ -106,6 +106,9 @@ type ColorMenuProps = {
 const ColorMenu = ({ icon, title, palette, onSelect, onClear }: ColorMenuProps) => {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  // Split the swatches into two balanced rows (e.g. 10 → 5+5, 12 → 6+6) instead
+  // of packing a fixed column count that leaves a ragged final row.
+  const columns = Math.ceil(palette.length / 2);
 
   useEffect(() => {
     if (!open) return;
@@ -124,8 +127,13 @@ const ColorMenu = ({ icon, title, palette, onSelect, onClear }: ColorMenuProps) 
         {icon}
       </ToolbarButton>
       {open && (
-        <div className="absolute left-0 top-9 z-50 w-40 rounded border border-stroke bg-white p-2 shadow-default dark:border-strokedark dark:bg-boxdark">
-          <div className="grid grid-cols-6 gap-1">
+        <div className="absolute left-0 top-9 z-50 w-max rounded border border-stroke bg-white p-2 shadow-default dark:border-strokedark dark:bg-boxdark">
+          <div
+            className="grid gap-1"
+            // Fixed tracks sized to the swatch (w-5 = 1.25rem) keep both rows snug
+            // and evenly filled; the popover (w-max) shrink-wraps to match.
+            style={{ gridTemplateColumns: `repeat(${columns}, 1.25rem)` }}
+          >
             {palette.map((hex) => (
               <button
                 key={hex}


### PR DESCRIPTION
- notes no longer collapse after colour changes inside notes on the right side
- notes have a collapse button reinstated
- notes no longer auto-collapse when clicking into the study space