### PR TITLE
Fix parallel-mode strophe-title misalignment by equalizing column widths

### DIFF
--- a/src/components/StudyPane/Passage/PassageBlock.tsx
+++ b/src/components/StudyPane/Passage/PassageBlock.tsx
@@ -13,8 +13,16 @@ export const LanguageContext = createContext({
 
 export const PassageBlock = ({
   displayMode,
+  columnRef,
+  sharedMinWidth,
 }: {
   displayMode: PassageDisplayMode;
+  // Set by Passage on the two parallel language columns: a callback ref to the
+  // stanza container (for measuring its natural width) and the shared min-width
+  // to apply so both language columns are the same width and a strophe-note
+  // title wraps identically in each. Undefined for single-language columns.
+  columnRef?: (node: HTMLDivElement | null) => void;
+  sharedMinWidth?: number | null;
 }) => {
 
   const { ctxPassageProps, ctxLanguageMode, ctxStropheNoteBtnOn, ctxReadmeBtnOn } = useContext(FormatContext);
@@ -64,7 +72,12 @@ export const PassageBlock = ({
   return (
     <LanguageContext.Provider value={languageContextValue}>
     <div id={`selaPassage_${displayMode}`} className={`${passageWidthClass} max-w-full flex relative px-2 py-4`}>
-        <div className={`flex ${stanzaLayoutClass}`}>
+        {/* min-width equalizes the two parallel language columns. Both the
+            measuring ref and the min-width live on THIS shrink-to-content (w-fit)
+            container so measure and constraint use the same box (converges instead
+            of drifting); its StanzaBlock children stretch, so the strophe boxes
+            widen and a strophe-note title wraps at the same width in both. */}
+        <div ref={columnRef} className={`flex ${stanzaLayoutClass}`} style={sharedMinWidth ? { minWidth: sharedMinWidth } : undefined}>
         {
             ctxPassageProps.stanzaProps.map((stanza) => {
             return (

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useMemo } from 'react';
+import React, { useEffect, useContext, useMemo, useCallback, useLayoutEffect } from 'react';
 
 import { FormatContext } from '../index';
 import { PassageBlock } from './PassageBlock';
@@ -48,7 +48,7 @@ const Passage = ({
     ctxSelectedStrophes, ctxSetSelectedStrophes, ctxSetNumSelectedStrophes,
     ctxStructureUpdateType, ctxSetStructureUpdateType, ctxAddToHistory, 
     ctxStudyNotes, ctxSetStudyNotes, ctxSetNoteMerge, ctxLanguageMode, ctxStropheNoteBtnOn, ctxReadmeBtnOn,
-    ctxNonEnglishDisplayMode,
+    ctxNonEnglishDisplayMode, ctxActiveLayerId,
   } = useContext(FormatContext);
 
   const nonEnglishDisplayMode =
@@ -58,6 +58,72 @@ const Passage = ({
       : "hebrew";
 
   const { isDragging, handleMouseDown, containerRef, getSelectionBoxStyle } = useDragToSelect(ctxPassageProps);
+
+  const isParallel = ctxLanguageMode === LanguageMode.Parallel;
+
+  // --- Parallel-mode title alignment ---------------------------------------
+  // The two language columns are independent DOM subtrees sized to their own
+  // content (w-fit), so a long strophe-note title wraps to a different number of
+  // lines in each, giving the columns different heights and knocking their rows
+  // out of alignment. Fix: measure each column's natural width and apply the max
+  // as a min-width to both, so the title wraps identically in each. Font, size
+  // and padding already match across columns, so equal width => equal wrapping.
+  //
+  // Skip it entirely (parallel layout untouched) when no strophe has a title, so
+  // views without titles don't get the trailing whitespace equalization adds.
+  const hasAnyStropheTitle = useMemo(() => {
+    if (!ctxStudyNotes) return false;
+    let parsed: Partial<StudyNotes> | null;
+    try {
+      parsed = JSON.parse(ctxStudyNotes) as Partial<StudyNotes> | null;
+    } catch {
+      return false;
+    }
+    if (!parsed) return false;
+    const layerStrophes = parsed.layerStrophes?.[String(ctxActiveLayerId)];
+    const rootStrophes = ctxActiveLayerId === 0 && Array.isArray(parsed.strophes) ? parsed.strophes : undefined;
+    const hasTitle = (note: StropheNote | undefined) =>
+      Boolean(note && typeof note.title === "string" && note.title.trim().length > 0);
+    return ctxPassageProps.stanzaProps.some((stanza) =>
+      stanza.strophes.some((strophe) =>
+        hasTitle(layerStrophes?.[strophe.stropheId] ?? rootStrophes?.[strophe.stropheId])
+      )
+    );
+  }, [ctxStudyNotes, ctxActiveLayerId, ctxPassageProps]);
+
+  const [hebColNode, setHebColNode] = useState<HTMLDivElement | null>(null);
+  const [glossColNode, setGlossColNode] = useState<HTMLDivElement | null>(null);
+  const [sharedColWidth, setSharedColWidth] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!isParallel || !hasAnyStropheTitle || !hebColNode || !glossColNode) {
+      setSharedColWidth(null);
+      return;
+    }
+    // Reset to natural widths first so measurement reflects real content (a stale
+    // min-width would otherwise pin both columns and never shrink).
+    setSharedColWidth(null);
+    let frame = 0;
+    const measure = () => {
+      const next = Math.max(hebColNode.offsetWidth, glossColNode.offsetWidth);
+      // Once the min-width is applied both columns report `next`, so this settles
+      // after one extra observer callback instead of oscillating.
+      setSharedColWidth((prev) => (prev !== null && Math.abs(prev - next) < 1 ? prev : next));
+    };
+    const schedule = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(measure);
+    };
+    schedule();
+    const observer = new ResizeObserver(schedule);
+    observer.observe(hebColNode);
+    observer.observe(glossColNode);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+    // Recompute from scratch when anything that changes natural width changes.
+  }, [isParallel, hasAnyStropheTitle, hebColNode, glossColNode, ctxPassageProps, ctxStropheNoteBtnOn, ctxReadmeBtnOn, nonEnglishDisplayMode]);
 
   // Build a map from wordId to stanza index for title merging
   const getWordToStanzaMap = useMemo(() => {
@@ -603,8 +669,8 @@ const Passage = ({
         }
         { ctxLanguageMode == LanguageMode.Parallel && 
           <div className={`flex flex-row mx-auto ${(ctxStropheNoteBtnOn || ctxLanguageMode == LanguageMode.Parallel) ? 'w-fit max-w-full' : 'w-[100%]'}`}>
-            <PassageBlock displayMode={nonEnglishDisplayMode}/>
-            <PassageBlock displayMode="gloss"/>
+            <PassageBlock displayMode={nonEnglishDisplayMode} columnRef={setHebColNode} sharedMinWidth={sharedColWidth}/>
+            <PassageBlock displayMode="gloss" columnRef={setGlossColNode} sharedMinWidth={sharedColWidth}/>
           </div>
         }
         { ctxLanguageMode == LanguageMode.Hebrew && 


### PR DESCRIPTION
In parallel display mode the two language columns are independent DOM subtrees each sized to their own content (w-fit). A long strophe-note title wraps to a different number of lines in each column, giving them different heights and knocking their rows out of alignment.

Font, size and padding already match across columns (.hbFont only sets direction), so equal usable width yields identical wrapping. Passage now measures each language column's natural width via a ResizeObserver and applies the max as a min-width to both. Measure and constraint sit on the same box so it converges instead of drifting; it's gated on hasAnyStropheTitle so title-less parallel views are left untouched.