### PR TITLE
Restrict study write access to owners—redirect non-owners to read-onl…

### DIFF
--- a/src/app/study/[id]/edit/page.tsx
+++ b/src/app/study/[id]/edit/page.tsx
@@ -29,17 +29,22 @@ export default async function StudyPage({ params }: { params: Promise<{ id: stri
     fetchPassageData(studyId)
   ]);
 
+  if (!result.study) {
+    notFound();
+  }
+
   /*
     Authorization check
-    Only the owner has write access to this study. Users will be redirected to the view page if the study is public.
+    Only the owner has write access to this study. Any other user — including
+    those opening a public / pre-marked / scriptura study — is redirected to the
+    read-only view page, which runs its own access check.
   */
-  if (!result.study || (thisUser?.id != result.study.owner && !result.study.public)) {
-    notFound();
+  if (thisUser?.id != result.study.owner) {
     return redirect(`/study/${id}/view`);
   }
 
   return (
       <StudyPane passageData={result} inViewMode={false}/>
-  );  
+  );
 
 }

--- a/src/components/StudyPane/InfoPane/Layers.tsx
+++ b/src/components/StudyPane/InfoPane/Layers.tsx
@@ -499,8 +499,9 @@ const Layers = () => {
                     )}
                     {editable && (
                       <button
-                        title="Delete layer"
-                        className="hover:opacity-70"
+                        title={ctxLayers.length <= 1 ? "At least one layer must exist" : "Delete layer"}
+                        className={ctxLayers.length <= 1 ? "cursor-default opacity-40" : "hover:opacity-70"}
+                        disabled={ctxLayers.length <= 1}
                         onClick={(e) => { e.stopPropagation(); requestDelete(layer.id); }}
                       >
                         <IconTrash size={ACTION_ICON_SIZE} style={{ pointerEvents: "none" }} />

--- a/src/components/StudyPane/Passage/StanzaBlock.tsx
+++ b/src/components/StudyPane/Passage/StanzaBlock.tsx
@@ -194,6 +194,24 @@ export const StanzaBlock = ({
       );
     }
 
+    // Read-only users can't edit the title, so never show the "Add stanza
+    // title..." affordance. Render an existing title as plain text; render
+    // nothing when there's no title.
+    if (ctxInViewMode) {
+      if (!hasTitle) {
+        return null;
+      }
+      return (
+        <span
+          className={`block w-full truncate py-1 text-base font-semibold ${ctxIsHebrew ? 'text-right' : 'text-left'} ${titleReservedSidePaddingClass}`}
+          dir="auto"
+          style={{ color: contrastingForegroundColor }}
+        >
+          {stanzaProps.metadata?.title}
+        </span>
+      );
+    }
+
     return (
       <button
         type="button"

--- a/src/components/StudyPane/Passage/StropheBlock.tsx
+++ b/src/components/StudyPane/Passage/StropheBlock.tsx
@@ -299,6 +299,9 @@ export const StropheBlock = ({
       <div
         className={actionButtonWrapperClass}
         >
+      {
+      /* The select icon only enables color editing, so hide it for read-only users. */
+      !ctxInViewMode &&
       <button
         key={"strophe" + stropheProps.stropheId + "Selector"}
         className={`${stanzaExpanded ? 'mx-[0.5]' : 'mx-1'} hover:bg-theme active:bg-transparent`}
@@ -311,8 +314,9 @@ export const StropheBlock = ({
           style={{pointerEvents:'none'}}
         />
       </button>
+      }
       {
-      expanded && stanzaExpanded && !ctxStropheNoteBtnOn ?
+      expanded && stanzaExpanded && !ctxStropheNoteBtnOn && !ctxInViewMode ?
       <button
         key={"strophe" + stropheProps.stropheId + "notepad"}
         className={`mx-[0.5] hover:bg-theme active:bg-transparent`}

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -906,7 +906,7 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
   );
 };
 
-export const StudyBtn = ({
+export const CloneStudyBtn = ({
   setCloneStudyOpen
 }: {
   setCloneStudyOpen: (arg: boolean) => void;

--- a/src/components/StudyPane/Toolbar/index.tsx
+++ b/src/components/StudyPane/Toolbar/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 
 import { UndoBtn, RedoBtn, ColorActionBtn, ClearFormatBtn, 
-  IndentBtn, UniformWidthBtn, StructureUpdateBtn, StudyBtn, 
+  IndentBtn, UniformWidthBtn, StructureUpdateBtn, CloneStudyBtn, 
   ClearAllFormatBtn, EditWordBtn, BoxlessBtn,
   StropheNoteBtn, ReadmeBtn} from "./Buttons";
 import ScaleDropDown from "./ScaleDropDown";
@@ -52,7 +52,7 @@ const Toolbar = ({
                 {
                   (study.model || study.scriptura) &&
                   (
-                    <StudyBtn setCloneStudyOpen={setCloneStudyOpen} />
+                    <CloneStudyBtn setCloneStudyOpen={setCloneStudyOpen} />
                   )
                 }
               </div>

--- a/src/components/StudyPane/index.tsx
+++ b/src/components/StudyPane/index.tsx
@@ -598,7 +598,9 @@ const StudyPane = ({
       }
       // Update the metadata with the new format
       studyMetadata.boxStyle = boxConfig;
-      updateMetadataInDb(passageData.study.id, studyMetadata);
+      if (!inViewMode) {
+        updateMetadataInDb(passageData.study.id, studyMetadata);
+      }
     }
     
     setBoxDisplayConfig(boxConfig || { style: BoxDisplayStyle.box });
@@ -609,13 +611,20 @@ const StudyPane = ({
   
   }, [passageData.bibleData, studyMetadata, readmeBtnOn]);
 
-  if (!passageData.study.metadata.words) {
-    let emptyStudyMetadata : StudyMetadata = { words: {} };
-    passageData.study.metadata = emptyStudyMetadata;
-    setStudyMetadata(emptyStudyMetadata);
-    setPointer(0);
-    updateMetadataInDb(passageData.study.id, emptyStudyMetadata);
-  }
+  // Initialise metadata for studies that have no `words` map yet. This runs as
+  // an effect (never during render) to avoid setState-in-render, and only
+  // persists for owners — read-only viewers must not write to the DB.
+  useEffect(() => {
+    if (!passageData.study.metadata.words) {
+      const emptyStudyMetadata: StudyMetadata = { words: {} };
+      passageData.study.metadata = emptyStudyMetadata;
+      setStudyMetadata(emptyStudyMetadata);
+      setPointer(0);
+      if (!inViewMode) {
+        updateMetadataInDb(passageData.study.id, emptyStudyMetadata);
+      }
+    }
+  }, [passageData.study, inViewMode]);
 
   return (
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -40,6 +40,26 @@ const formatStrongNumberForDisplay = (value: string) => {
 };
 
 
+/*
+  Server-side write guard. Server actions are directly invocable by any signed-in
+  client, so gating the UI is not enough: every action that mutates an existing
+  study must confirm the caller owns it. Returns true only when the current user
+  is the study's owner. Queries just the owner column to keep the check cheap.
+*/
+async function isStudyOwner(studyId: string): Promise<boolean> {
+  const user = await currentUser();
+  if (!user) return false;
+
+  const row = await db
+    .select({ owner: study.owner })
+    .from(study)
+    .where(eq(study.id, studyId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+
+  return !!row && row.owner === user.id;
+}
+
 export async function fetchStudyById(studyId: string) {
   try {
     const row = await db
@@ -71,6 +91,9 @@ export async function fetchStudyById(studyId: string) {
 }
 
 export async function updateStudyName(id: string, studyName: string) {
+  if (!(await isStudyOwner(id))) {
+    return { message: 'Unauthorized: You do not have permission to modify this study.' };
+  }
   try {
     const result = await db
       .update(study)
@@ -98,6 +121,9 @@ export async function updateStudyNotes(id: string, content: string) {
 }
 
 export async function updatePublic(studyId: string, publicAccess: boolean) {
+  if (!(await isStudyOwner(studyId))) {
+    return { message: 'Unauthorized: You do not have permission to modify this study.' };
+  }
   try {
     await db
       .update(study)
@@ -109,6 +135,9 @@ export async function updatePublic(studyId: string, publicAccess: boolean) {
 }
 
 export async function updateStar(studyId: string, isStarred: boolean) {
+  if (!(await isStudyOwner(studyId))) {
+    return { message: 'Unauthorized: You do not have permission to modify this study.' };
+  }
   try {
     await db
       .update(study)
@@ -121,6 +150,10 @@ export async function updateStar(studyId: string, isStarred: boolean) {
 
 export async function updateMetadataInDb(studyId: string, studyMetadata: StudyMetadata) {
   "use server";
+
+  if (!(await isStudyOwner(studyId))) {
+    return { message: 'Unauthorized: You do not have permission to modify this study.' };
+  }
 
   try {
     const metadataJson = JSON.stringify(studyMetadata);
@@ -137,6 +170,9 @@ export async function updateMetadataInDb(studyId: string, studyMetadata: StudyMe
 }
 
 export async function deleteStudy(studyId: string) {
+  if (!(await isStudyOwner(studyId))) {
+    return { message: 'Unauthorized: You do not have permission to delete this study.' };
+  }
   try {
     const result = await db
       .delete(study)
@@ -203,6 +239,7 @@ export async function cloneStudy(originalStudy: StudyData, newName: string) {
           passage: originalStudy.passage,
           owner: user.id,
           metadata: originalStudy.metadata,
+          notes: originalStudy.notes,
           public: false,
           model: false,
           starred: false,


### PR DESCRIPTION
…y view, guard mutating server actions with an ownership check, and clone a study's notes on duplication.

Hide/disable edit affordances (strophe select & note-pencil, stanza title, last-layer trash) for read-only users